### PR TITLE
Add more efficient bpvec implementations for Snow and Dopar params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,5 +9,5 @@ Description: This package provides modified versions and novel
   with Bioconductor objects.
 biocViews: HighThroughputSequencing, Infrastructure
 License: GPL-2 | GPL-3
-Imports: methods, parallel, foreach, tools
+Imports: methods, parallel, foreach, iterators, tools
 Suggests: BiocGenerics, doParallel

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,6 +7,8 @@ import(parallel)
 importFrom(foreach, "%dopar%", foreach, getDoParName,
     getDoParRegistered, getDoParWorkers)
 
+importFrom(iterators, isplit)
+
 importFrom(tools, SIGTERM)
 
 exportClass(BiocParallelParam, MulticoreParam, SnowParam,

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -54,7 +54,6 @@ setMethod(bpvec, c("ANY", "ANY", "DoparParam"),
         return(bpvec(X, FUN, ..., param=SerialParam()))
     si <- .splitIndices(length(X), bpworkers(param))
     sf <- factor(rep(seq_along(si), sapply(si, length)))
-    X.iter <- isplit(X, sf)
-    res <- bplapply(X.iter, FUN, ..., param)
-    do.call(c, unname(res))
+    x <- NULL                           # For R CMD check
+    foreach(x=isplit(X, sf), .combine=c) %dopar% FUN(x$value, ...)
 })

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -45,3 +45,16 @@ setMethod(bplapply, c("ANY", "ANY", "DoparParam"),
     ans <- foreach(x=X) %dopar% FUN(x, ...)
     setNames(ans, names(X))
 })
+
+setMethod(bpvec, c("ANY", "ANY", "DoparParam"),
+    function(X, FUN, ..., param)
+{
+    FUN <- match.fun(FUN)
+    if (!bpisup(param))
+        return(bpvec(X, FUN, ..., param=SerialParam()))
+    si <- .splitIndices(length(X), bpworkers(param))
+    sf <- factor(rep(seq_along(si), elementLengths(si)))
+    X.iter <- isplit(X, sf)
+    res <- bplapply(X.iter, FUN, ..., param)
+    do.call(c, unname(res))
+})

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -53,7 +53,7 @@ setMethod(bpvec, c("ANY", "ANY", "DoparParam"),
     if (!bpisup(param))
         return(bpvec(X, FUN, ..., param=SerialParam()))
     si <- .splitIndices(length(X), bpworkers(param))
-    sf <- factor(rep(seq_along(si), elementLengths(si)))
+    sf <- factor(rep(seq_along(si), sapply(si, length)))
     X.iter <- isplit(X, sf)
     res <- bplapply(X.iter, FUN, ..., param)
     do.call(c, unname(res))

--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -90,6 +90,21 @@ setMethod(bplapply, c("ANY", "ANY", "SnowParam"),
     parLapply(bpbackend(param), X, FUN, ...)
 })
 
+setMethod(bpvec, c("ANY", "ANY", "SnowParam"),
+    function(X, FUN, ..., param)
+{
+    FUN <- match.fun(FUN)
+    if (!bpisup(param)) {
+        param <- bpstart(param)
+        on.exit(bpstop(param))
+    }
+    cl <- bpbackend(param)
+    si <- .splitIndices(length(X), bpworkers(param))
+    argfun <- function(i) c(list(X[si[[i]]]), list(...))
+    res <- parallel:::staticClusterApply(cl, FUN, length(si), argfun)
+    do.call(c, unname(res))
+})
+
 setMethod(show, "SnowParam",
     function(object)
 {


### PR DESCRIPTION
As discussed, I implemented proper splitting for both the Dopar and Snow backends. These implementations don't send the full object to every worker, and they also don't ever create the full split object.