### PR TITLE
remove 128L workers limitation when using MPI

### DIFF
--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -204,7 +204,7 @@ setMethod("bpstart", "SnowParam",
         stop("cluster not started; no workers specified")
 
     nnodes <- min(bpnworkers(x), lenX)
-    if (nnodes > 128L - nrow(showConnections(all=TRUE)))
+    if (x$.clusterargs$type != "MPI" & nnodes > 128L - nrow(showConnections(all=TRUE)))
         stop("cannot create ", nnodes, " workers; ",
              128L - nrow(showConnections(all=TRUE)),
              " connections available in this session")


### PR DESCRIPTION
See issue #55 

```r
> library(devtools)
> install_github("lgatto/BiocParallel")
Downloading GitHub repo lgatto/BiocParallel@master
from URL https://api.github.com/repos/lgatto/BiocParallel/zipball/master
Installing BiocParallel
'/opt/Rpatched/lib/R/bin/R' --no-site-file --no-environ --no-save  \
  --no-restore --quiet CMD INSTALL  \
  '/tmp/RtmpVPu9K7/devtoolsa82038bcbd26/lgatto-BiocParallel-4daff56'  \
  --library='/opt/Rpatched/lib/R/library' --install-tests 

* installing *source* package ‘BiocParallel’ ...
** R
** inst
** tests
** preparing package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded
* DONE (BiocParallel)
> library(BiocParallel)
> p = SnowParam(132L, type = "MPI")
> head(res2 <- bpvec(1:132, get("+"), 1, BPPARAM=p))
Loading required namespace: Rmpi
	132 slaves are spawned successfully. 0 failed.
starting MPI worker

starting MPI worker
...
starting MPI worker

starting MPI worker

[1] 2 3 4 5 6 7
> identical(res2, 1:132+1)
[1] TRUE
```
