### PR TITLE
Add progress bar to SerialParam

### DIFF
--- a/R/BatchtoolsParam-class.R
+++ b/R/BatchtoolsParam-class.R
@@ -407,7 +407,8 @@ setMethod("bpiterate", c("ANY", "ANY", "BatchtoolsParam"),
     if (!bpschedule(BPPARAM) || bpnworkers(BPPARAM) == 1L) {
         param <- SerialParam(stop.on.error=bpstopOnError(BPPARAM),
                              log=bplog(BPPARAM),
-                             threshold=bpthreshold(BPPARAM))
+                             threshold=bpthreshold(BPPARAM),
+                             progress=bpprogressbar(BPPARAM))
         return(bpiterate(ITER, FUN, ..., REDUCE=REDUCE, init=init,
                          BPPARAM=param))
     }

--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -26,14 +26,16 @@
 
 SerialParam <-
     function(catch.errors=TRUE, stop.on.error = TRUE,
-             log=FALSE, threshold="INFO", logdir=NA_character_)
+             log=FALSE, threshold="INFO", logdir=NA_character_,
+             progressbar=FALSE)
 {
     if (!missing(catch.errors))
         warning("'catch.errors' is deprecated, use 'stop.on.error'")
 
     x <- .SerialParam(workers=1L, catch.errors=catch.errors,
                       stop.on.error=stop.on.error,
-                      log=log, threshold=threshold, logdir=logdir) 
+                      log=log, threshold=threshold, logdir=logdir,
+                      progressbar=progressbar)
     validObject(x)
     x
 }
@@ -101,7 +103,14 @@ setMethod("bplapply", c("ANY", "SerialParam"),
                        stop.immediate=bpstopOnError(BPPARAM),
                        timeout=bptimeout(BPPARAM))
 
-    res <- lapply(X, FUN, ...)
+    progress <- .progress(active=bpprogressbar(BPPARAM))
+    on.exit(progress$term(), TRUE)
+    progress$init(length(X))
+    FUN_ <- function(...) {
+        progress$step()
+        FUN(...)
+    }
+    res <- lapply(X, FUN_, ...)
 
     names(res) <- names(X)
 
@@ -160,6 +169,13 @@ setMethod("bpiterate", c("ANY", "ANY", "SerialParam"),
 
     FUN <- .composeTry(FUN, bplog(BPPARAM), bpstopOnError(BPPARAM),
                        timeout=bptimeout(BPPARAM))
+    progress <- .progress(active=bpprogressbar(BPPARAM), iterate=TRUE)
+    on.exit(progress$term(), TRUE)
+    progress$init()
+    FUN_ <- function(...) {
+        progress$step()
+        FUN(...)
+    }
 
-    .bpiterate_serial(ITER, FUN, ..., REDUCE = REDUCE, init = init)
+    .bpiterate_serial(ITER, FUN_, ..., REDUCE = REDUCE, init = init)
 })

--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -107,8 +107,9 @@ setMethod("bplapply", c("ANY", "SerialParam"),
     on.exit(progress$term(), TRUE)
     progress$init(length(X))
     FUN_ <- function(...) {
-        FUN(...)
+        value <- FUN(...)
         progress$step()
+        value
     }
     res <- lapply(X, FUN_, ...)
 
@@ -173,8 +174,9 @@ setMethod("bpiterate", c("ANY", "ANY", "SerialParam"),
     on.exit(progress$term(), TRUE)
     progress$init()
     FUN_ <- function(...) {
-        FUN(...)
+        value <- FUN(...)
         progress$step()
+        value
     }
 
     .bpiterate_serial(ITER, FUN_, ..., REDUCE = REDUCE, init = init)

--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -107,8 +107,8 @@ setMethod("bplapply", c("ANY", "SerialParam"),
     on.exit(progress$term(), TRUE)
     progress$init(length(X))
     FUN_ <- function(...) {
-        progress$step()
         FUN(...)
+        progress$step()
     }
     res <- lapply(X, FUN_, ...)
 
@@ -173,8 +173,8 @@ setMethod("bpiterate", c("ANY", "ANY", "SerialParam"),
     on.exit(progress$term(), TRUE)
     progress$init()
     FUN_ <- function(...) {
-        progress$step()
         FUN(...)
+        progress$step()
     }
 
     .bpiterate_serial(ITER, FUN_, ..., REDUCE = REDUCE, init = init)

--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -397,7 +397,8 @@ setMethod("bplapply", c("ANY", "SnowParam"),
     if (!bpschedule(BPPARAM) || length(X) == 1L || bpnworkers(BPPARAM) == 1L) {
         param <- SerialParam(stop.on.error=bpstopOnError(BPPARAM),
                              log=bplog(BPPARAM),
-                             threshold=bpthreshold(BPPARAM))
+                             threshold=bpthreshold(BPPARAM),
+                             progressbar=bpprogressbar(BPPARAM))
         return(bplapply(X, FUN, ..., BPREDO=BPREDO, BPPARAM=param))
     }
 
@@ -462,7 +463,8 @@ setMethod("bpiterate", c("ANY", "ANY", "SnowParam"),
     if (!bpschedule(BPPARAM) || bpnworkers(BPPARAM) == 1L) {
         param <- SerialParam(stop.on.error=bpstopOnError(BPPARAM),
                              log=bplog(BPPARAM),
-                             threshold=bpthreshold(BPPARAM))
+                             threshold=bpthreshold(BPPARAM),
+                             progress=bpprogressbar(BPPARAM))
         return(bpiterate(ITER, FUN, ..., REDUCE=REDUCE, init=init,
                          BPPARAM=param))
     }

--- a/man/SerialParam-class.Rd
+++ b/man/SerialParam-class.Rd
@@ -23,7 +23,7 @@
 
 \usage{
 SerialParam(catch.errors = TRUE, stop.on.error = TRUE, log = FALSE,
-    threshold = "INFO", logdir= NA_character_)
+    threshold = "INFO", logdir = NA_character_, progressbar = FALSE)
 }
 
 \section{Constructor}{
@@ -58,6 +58,10 @@ SerialParam(catch.errors = TRUE, stop.on.error = TRUE, log = FALSE,
   \item{logdir}{
     \code{character(1)} Log files directory. When not provided, log
     messages are returned to stdout.
+  }
+
+  \item{progressbar}{
+    \code{logical(1)} Enable progress bar (based on plyr:::progress_text).
   }
 }
 


### PR DESCRIPTION
Add support for use with `bplapply()` and `bpiterate()`.
Where a _SerialParam_ is constructed from a `BPPARAM` that is a _SnowParam_/_MulticoreParam_ or _BatchtoolsParam_, the _SerialParam_ sets the progress bar by inspecting `bpprogressbar(BPPARAM)`.

I haven't yet bumped the version number or updated `NEWS`. 
