### PR TITLE
Supress slurm queue printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.17.0
+Version: 1.17.1
 Authors@R: c(
     person("Bioconductor Package Maintainer",
         email="maintainer@bioconductor.org", role="cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.15.15
+Version: 1.15.16
 Authors@R: c(
     person("Bioconductor Package Maintainer",
         email="maintainer@bioconductor.org", role="cre"),

--- a/R/BatchtoolsParam-class.R
+++ b/R/BatchtoolsParam-class.R
@@ -47,7 +47,7 @@ batchtoolsCluster <-
         multicore = .Platform$OS.type != "windows",
         interactive = TRUE,
         sge = suppressWarnings(system2("qstat", stderr=NULL) != 127L),
-        slurm = suppressWarnings(system2("squeue", stderr=NULL) != 127L),
+        slurm = suppressWarnings(system2("squeue", stderr=NULL, stdout=NULL) != 127L),
         lsf = suppressWarnings(system2("bjobs", stderr=NULL) != 127L),
         openlava = suppressWarnings(system2("bjobs", stderr=NULL) != 127L),
         torque = suppressWarnings(system2("qselect", stderr=NULL) != 127L),


### PR DESCRIPTION
Every time you run `BatchtoolsParam(cluster = "slurm")` it runs the system command `squeue` which for me seems to output to `stdout` rather than `stderr`, and results in thousands of lines printed in the R console.  This patch just redirects stdout to NULL.  It might be useful for other cluster types too.