### PR TITLE
Bpvalidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.23.0
+Version: 1.23.1
 Authors@R: c(
     person("Bioconductor Package Maintainer",
         email="maintainer@bioconductor.org", role="cre"),

--- a/R/bpvalidate.R
+++ b/R/bpvalidate.R
@@ -41,7 +41,9 @@ bpvalidate <- function(fun)
     inpath <- structure(list(), names=character())
     if (length(unknown)) {
         inpath <- .foundInPath(unknown)
+        inlocal <- ls(environment(fun))
         unknown <- setdiff(unknown, names(inpath))
+        unknown <- setdiff(unknown, inlocal)
         inpath <- .filterDefaultPackages(inpath)
     }
     if (length(unknown))

--- a/R/bpvalidate.R
+++ b/R/bpvalidate.R
@@ -45,7 +45,7 @@ bpvalidate <- function(fun)
         inpath <- .filterDefaultPackages(inpath)
 
         env <- environment(fun)
-        while(!identical( env, globalenv())) {
+        while(!identical(env, topenv(environment(fun)))) {
             inlocal <- ls(env, all.names = TRUE)
             unknown <- setdiff(unknown, inlocal)
             env <- parent.env(env)

--- a/R/bpvalidate.R
+++ b/R/bpvalidate.R
@@ -41,13 +41,22 @@ bpvalidate <- function(fun)
     inpath <- structure(list(), names=character())
     if (length(unknown)) {
         inpath <- .foundInPath(unknown)
-        inlocal <- ls(environment(fun))
         unknown <- setdiff(unknown, names(inpath))
-        unknown <- setdiff(unknown, inlocal)
         inpath <- .filterDefaultPackages(inpath)
+
+        env <- environment(fun)
+        while(!identical( env, globalenv())) {
+            inlocal <- ls(env, all.names = TRUE)
+            unknown <- setdiff(unknown, inlocal)
+            env <- parent.env(env)
+        }
     }
+
     if (length(unknown))
         warning("function references unknown symbol(s)")
+
+    if (any(inpath %in% ".GlobalEnv"))
+        warning("function references symbol(s) in .GlobalEnv")
 
     list(inPath=inpath, unknown=unknown)
 }

--- a/inst/unitTests/test_bpvalidate.R
+++ b/inst/unitTests/test_bpvalidate.R
@@ -11,6 +11,9 @@ test_bpvalidate_basic_ok <- function()
     checkIdentical(target, bpvalidate(function(y, x) y(x=x) ))
     checkIdentical(target, bpvalidate(function(y, ...) y(...) ))
     checkIdentical(target, bpvalidate(local({i = 2; function(y) y + i})))
+    checkIdentical(target,
+                   bpvalidate(local({i = 2; local({function(y) y + i})}))
+                  )
 }
 
 test_bpvalidate_basic_fail <- function()

--- a/inst/unitTests/test_bpvalidate.R
+++ b/inst/unitTests/test_bpvalidate.R
@@ -10,6 +10,7 @@ test_bpvalidate_basic_ok <- function()
     checkIdentical(target, bpvalidate(function(y, x) y(x)   ))
     checkIdentical(target, bpvalidate(function(y, x) y(x=x) ))
     checkIdentical(target, bpvalidate(function(y, ...) y(...) ))
+    checkIdentical(target, bpvalidate(local({i = 2; function(y) y + i})))
 }
 
 test_bpvalidate_basic_fail <- function()


### PR DESCRIPTION
These are changes to bpvalidate to properly handle the use of `local` variables and to warn when global variables are used. The following now function properly:

```
g = local({ i = 2; function(x) x + i })
bpvalidate(g)

g <- local({ i = 2; local({ function(y) y + i })})
bpvalidate(g)

i = 2; g = function(x) x + i
bpvalidate(g)               ## Now gives a warning
```