### PR TITLE
Force garbage collection after running FUN.

### DIFF
--- a/R/ErrorHandling.R
+++ b/R/ErrorHandling.R
@@ -75,11 +75,19 @@ bptry <- function(expr, ..., bplist_error, bperror)
         if (stop.on.error && ERROR_OCCURRED) {
             UNEVALUATED
         } else {
-            withCallingHandlers({
+            output <- withCallingHandlers({
                 tryCatch({
                     FUN(...)
                 }, error=handle_error)
             }, warning=handle_warning)
+
+            # Trigger garbage collection to cut down on memory usage within
+            # each worker in shared memory contexts. Otherwise, each worker is
+            # liable to think the entire heap is available (leading to each
+            # worker trying to fill said heap, causing R to exhaust memory).
+            gc(verbose=FALSE, full=FALSE)
+
+            output
         }
     }
 }


### PR DESCRIPTION
This provides one solution to the problem discussed today on Slack, to wit:

```r
library(BiocParallel)
big <- runif(5e8)
BPPARAM <- MulticoreParam(workers=10)
bplapply(1:1000, function(i) { out <- sum(runif(1e7)); out }, BPPARAM=BPPARAM)
```

This should use 4 GB for `big` plus another 80 MB per worker, totalling to just under 5 GB. Indeed, my laptop reports about 6 GB RAM used after `big` is constructed, consistent with a bit of OS overhead. However, running the `bplapply` causes my laptop to go into swap, despite having a total of 16 GB RAM that should be more than enough to handle the 800 MB across all workers.

I think the underlying problem is that each forked process believes that the entirety of the parent's heap is available. When allocations are made in one child, I assume that the affected space doesn't show up as being used in another child; rather, the pages are copied so that the second child can still use that space for its own allocations. This increases the overall memory usage as expected, but the real issue is that this slips past the garbage collector. Within each child, there is no reason to trigger the GC as - for all it knows - it has plenty of remaining memory in the heap to work with, so why bother? As a consequence, each worker uses a profligate amount of memory across repeated `FUN` calls, roughly equivalent to the size of the heap in the parent. 

This PR works towards a solution by forcing garbage collection at the end of each evaluation of `FUN`, which allows the code above to proceed without entering swap - total RAM usage hovers around ~7GB, consistent with the budgeting above. There is probably a better place to put this instead of `.composeTry`; that was just for convenience. I could also imagine an additional generic to only perform garbage collection in certain parallelization contexts (e.g., forking only) and in a user-tunable manner.