### PR TITLE
Demonstration of job-specific seeds

### DIFF
--- a/R/ErrorHandling.R
+++ b/R/ErrorHandling.R
@@ -66,9 +66,12 @@ bptry <- function(expr, ..., bplist_error, bperror)
         else e
     }
 
-    function(...) {
+    function(..., .BiocParallel.seed) {
         setTimeLimit(timeout, timeout, TRUE)
         on.exit(setTimeLimit(Inf, Inf, FALSE))
+
+        RNGkind("L'Ecuyer-CMRG")
+        assign(".Random.seed", .BiocParallel.seed, envir = .GlobalEnv)
 
         if (exportglobals)
             base::options(global_options)

--- a/R/ErrorHandling.R
+++ b/R/ErrorHandling.R
@@ -70,7 +70,8 @@ bptry <- function(expr, ..., bplist_error, bperror)
         setTimeLimit(timeout, timeout, TRUE)
         on.exit(setTimeLimit(Inf, Inf, FALSE))
 
-        RNGkind("L'Ecuyer-CMRG")
+        old <- RNGkind("L'Ecuyer-CMRG")
+        on.exit(RNGkind(old[1]))
         assign(".Random.seed", .BiocParallel.seed, envir = .GlobalEnv)
 
         if (exportglobals)

--- a/R/bplapply-methods.R
+++ b/R/bplapply-methods.R
@@ -73,12 +73,16 @@ setMethod("bplapply", c("ANY", "list"),
         timeout=bptimeout(BPPARAM), exportglobals=bpexportglobals(BPPARAM)
     )
 
+    ## manufacture seeds
+    seeds <- .define_seeds(bpRNGseed(BPPARAM), length(X))
+
     ## split into tasks
     X <- .splitX(X, bpnworkers(BPPARAM), bptasks(BPPARAM))
-    ARGFUN <- function(i) c(list(X=X[[i]]), list(FUN=FUN), list(...))
+    seeds <- .splitX(seeds, bpnworkers(BPPARAM), bptasks(BPPARAM))
+    ARGFUN <- function(i) c(list(X[[i]], .BiocParallel.seed=seeds[[i]]), list(FUN=FUN), list(MoreArgs=list(...), SIMPLIFY=FALSE))
 
     cls <- structure(list(), class="lapply")
-    res <- bploop(cls, X, lapply, ARGFUN, BPPARAM)
+    res <- bploop(cls, X, mapply, ARGFUN, BPPARAM)
 
     if (!is.null(res)) {
         res <- do.call(unlist, list(res, recursive=FALSE))

--- a/R/bpstart-methods.R
+++ b/R/bpstart-methods.R
@@ -98,7 +98,8 @@ setMethod("bpstart", "missing",
         if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
             get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
         } else NULL
-    RNGkind("L'Ecuyer-CMRG")
+    old <- RNGkind("L'Ecuyer-CMRG")
+    on.exit(RNGkind(old[1]))
     if (!is.null(init_seed))
         set.seed(init_seed)
     seeds <- vector("list", n)


### PR DESCRIPTION
This is a proof of concept for job-specific seeds. The idea is that a seed (conflated with stream for the L'Ecuyer RNG) is defined for each job, usually in the serial section ; the relevant seeds are distributed along with the other job parameters to the workers; and the seed is set to the specified value prior to each call to `FUN`. This ensures that, no matter how the jobs are split up among the workers, the same result is obtained. 

The same cannot be said for the current set-up. Partly because the seed is set once per worker, such that changes in the number of workers will yield different results; but mostly because of #122, which means that the seed isn't really respected anyway for the most common use case of `MulticoreParam()`.

The current PR has known gaps - doesn't work for `SerialParam()`, for example - but these can be easily fixed.