### PR TITLE
Avoid using `seq_along` with the backend object

### DIFF
--- a/R/bpstop-methods.R
+++ b/R/bpstop-methods.R
@@ -15,8 +15,7 @@ setMethod("bpstop", "missing",
     function(x)
 {
     cluster <- bpbackend(x)
-    for (i in seq_along(cluster))
-        .send_to(cluster, i, .DONE())
+    .send_all(cluster, .DONE())
 
     TRUE
 }


### PR DESCRIPTION
I feel applying `seq_along` to the backend object can be troublesome. It works for SnowParam as each element in the backend representing a worker, but for RedisParam there is no worker object(because we are communicating with a Redis server), so the code
```
.bpstop_nodes <-
    function(x)
{
    cluster <- bpbackend(x)
    for (i in seq_along(cluster))
        .send_to(cluster, i, .DONE())

    TRUE
}
```
will incorrectly send the DONE message `length(cluster)` times to integer value queues. As `seq_along` is not a generic function, it cannot be fixed by overwriting the function. This pull request is a quick fix for `bpstop_nodes`, but looping over all workers cannot be completely avoided for `.bpstart_set_rng_seed` and `bpstop`.

I suggest we add a new generic to get all workers from a backend, and then loop over the returned workers. Perhaps `.node` or `.workers`? the generic can simply return the backend itself by default so it will be compatible with the old code.

Best,
Jiefei



