### PR TITLE
Impove the performance of the RNG seed generator

### DIFF
--- a/R/rng.R
+++ b/R/rng.R
@@ -117,10 +117,12 @@
     for (i in seq_len(n)) {
         ## generate a seed for each element of X
         SEED <- .rng_next_substream(SEED)
-        if (i %in% keep) {
+        if (i == keep[ith_task]) {
             ## keep only the first element of each task
             task_seeds[[ith_task]] <- SEED
             ith_task <- ith_task + 1L
+            if (ith_task > length(keep))
+                break
         }
     }
 


### PR DESCRIPTION
Hi, this pull request gives a slight performance boost for `.rng_seeds_by_task`. The function determines whether to keep the ith RNG stream by searching the index `i` in the vector `keep`. However, the search can be slow when the vector `keep` is large, so I replace the search with a comparison. The improvement can be non-trivial when `bptasks()` is large, here is a simple code to see the performance difference.

```
library(BiocParallel)
p <- SerialParam(RNGseed = 1)
n <- 100000
system.time(
  BiocParallel:::.rng_seeds_by_task(p, rep(TRUE, n), rep(1, n))
)
```
For the master branch, the result is
```
   user  system elapsed 
   5.32    6.18   11.47 
```
With the change, the result is
```
   user  system elapsed 
   0.14    0.00    0.14 
```


Best,
Jiefei