### PR TITLE
Subsetting X using `[` instead of `[[`

### DIFF
--- a/R/bploop.R
+++ b/R/bploop.R
@@ -204,7 +204,7 @@
             i <<- i + 1L
             X[[i]]
         } else {
-            NULL
+            list(NULL)
         }
     }
 }
@@ -274,7 +274,8 @@ bploop.iterate <-
 
     ARGFUN <- function(X, seed)
         c(
-            list(X=X), list(FUN=FUN), ARGS,
+            list(X=X, BPELEMENTS = length(X)),
+            list(FUN=FUN), ARGS,
             list(BPRNGSEED = seed)
         )
     ## initial load
@@ -288,7 +289,7 @@ bploop.iterate <-
             seed <- .rng_iterate_substream(seed, value)
             value <- ITER()
         }
-        if (is.null(value[[1]])) {
+        if (identical(value, list(NULL))) {
             if (i == 1L)
                 warning("first invocation of 'ITER()' returned NULL")
             break
@@ -329,7 +330,7 @@ bploop.iterate <-
             seed <- .rng_iterate_substream(seed, value)
             value <- ITER()
         }
-        if (!is.null(value[[1]])) {
+        if (!identical(value, list(NULL))) {
             i <- i + 1L
             value_ <- .EXEC(i, .rng_lapply, ARGFUN(value, seed))
             running[d$node] <- .send_to(cl, d$node, value_)

--- a/R/rng.R
+++ b/R/rng.R
@@ -133,11 +133,23 @@
 ## lapply, but with 'FUN()' wrapped so that each call uses a new
 ## random number stream
 .rng_lapply <-
-    function(X, FUN, ..., BPRNGSEED)
+    function(X, FUN, ..., BPRNGSEED, BPELEMENTS)
 {
     state <- .rng_get_generator()
     on.exit(.rng_reset_generator(state$kind, state$seed))
 
     FUN <- .rng_job_fun_factory(FUN, BPRNGSEED)
-    lapply(X, FUN, ...)
+    tryCatch(
+        lapply(X, FUN, ...),
+        error = function(e) {
+            call <- sapply(sys.calls(), deparse, nlines=3)
+            if (BPELEMENTS == 0) {
+                list()
+            } else if (BPELEMENTS == 1 ) {
+                list(.error_remote(e, call))
+            } else {
+                c(list(.error_remote(e, call)), rep(list(.error_unevaluated()), BPELEMENTS - 1L))
+            }
+        }
+    )
 }


### PR DESCRIPTION
This pull request tries to avoid the use of `[[` on the variable `X` in `bplapply` and solves the following issue
```
.A = setClass("A", slots = c(a = "integer"))
setMethod("[", "A", function(x, i, j, ...) initialize(x, a = x@a[i]))
setMethod("length", "A", function(x) length(x@a))
as.list.A <- function(x, ...)
    lapply(seq_along(x), function(i) x[i])

x = .A(a = 1:3)
lapply(x, function(elt) elt@a)    # works because `lapply()` calls 'as.list' -- expensive
bplapply(x, function(elt) elt@a)  # fails because there is no `[[` method
```
Note that this can still fail for `SnowParam` as the worker does not have the definition of the class `A`(but works if the definition of `A` is in a package), so I edit `rng_apply` to make it fails gracefully.