### PR TITLE
Transient multicore param regression

### DIFF
--- a/R/TransientMulticoreParam-class.R
+++ b/R/TransientMulticoreParam-class.R
@@ -17,9 +17,7 @@ setMethod(
     "bpstart", "TransientMulticoreParam",
     function(x, ...)
 {
-    .rng_internal_stream$set()
     parallel::mccollect(wait=TRUE)
-    .rng_internal_stream$reset()
 
     rm(
         list=ls(envir = .TRANSIENTMULTICOREPARAM_JOBNODE),
@@ -87,9 +85,7 @@ setMethod(
             for (id in names(result))
                 .BUFF[[id]] <- result[[id]]
         }
-        .rng_internal_stream$set()
-        id <- sample(names(.BUFF), 1L)
-        .rng_internal_stream$reset()
+        id <- head(names(.BUFF), 1L)
 
         value <- .BUFF[[id]]
         rm(list = id, envir = .BUFF)


### PR DESCRIPTION
This functionality was available prior to recent changes. It's important because it can provide significant speed-up when there is a lot of data, and for the common use case where the `BPPARAM` has not been started by the user.
```
f <-
    function(param, y)
{
    bplapply(1:100, function(x, y) sum(y), y = y, BPPARAM = param)
}

y <- rnorm(1000000)
param = MulticoreParam(tasks = 100)
system.time(f(param, y)) # less than 1s
param <- bpstart(MulticoreParam(tasks = 100))
system.time(f(param, y)) # more than 4s
```