### PR TITLE
accept `bplist_error` as the argument of BPREDO

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -40,6 +40,9 @@ export(
     ## error handlers
     bptry,
 
+    ## accessor for the errors
+    bperror,
+
     ## helpers
     bploop,                             # worker, manager loops
     multicoreWorkers, snowWorkers,

--- a/R/BatchJobsParam-class.R
+++ b/R/BatchJobsParam-class.R
@@ -108,6 +108,8 @@ setMethod("bplapply", c("ANY", "BatchJobsParam"),
 {
     FUN <- match.fun(FUN)
 
+    BPREDO <- bperror(BPREDO)
+
     if (!length(X))
         return(.rename(list(), X))
 

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -4,7 +4,7 @@
 
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-### Constructor 
+### Constructor
 ###
 
 .DoparParam_prototype <- .BiocParallelParam_prototype
@@ -69,6 +69,8 @@ setMethod("bplapply", c("ANY", "DoparParam"),
 
     FUN <- match.fun(FUN)
 
+    BPREDO <- bperror(BPREDO)
+
     idx <- .redo_index(X, BPREDO)
     if (any(idx))
         X <- X[idx]
@@ -102,7 +104,7 @@ setMethod("bplapply", c("ANY", "DoparParam"),
 
     if (any(idx)) {
         BPREDO[idx] <- res
-        res <- BPREDO 
+        res <- BPREDO
     }
 
     if (!all(bpok(res)))

--- a/R/ErrorHandling.R
+++ b/R/ErrorHandling.R
@@ -1,10 +1,11 @@
 ### =========================================================================
-### Error handling 
+### Error handling
 ### -------------------------------------------------------------------------
 
 bpok <-
     function(x, type = bperrorTypes())
 {
+    x <- bperror(x)
     type <- match.arg(type)
     !vapply(x, inherits, logical(1), type)
 }
@@ -12,12 +13,18 @@ bpok <-
 bptry <- function(expr, ..., bplist_error, bperror)
 {
     if (missing(bplist_error))
-        bplist_error <- function(err)
-            attr(err, "result")
+        bplist_error <- BiocParallel::bperror
 
     if (missing(bperror))
         bperror <- identity
     tryCatch(expr, ..., bplist_error=bplist_error, bperror=bperror)
+}
+
+bperror <- function(x)
+{
+    if (is(x, "bplist_error"))
+        x <- attr(x, "result")
+    x
 }
 
 .composeTry <- function(FUN, log, stop.on.error,
@@ -103,7 +110,7 @@ bptry <- function(expr, ..., bplist_error, bperror)
 .condition_remote <- function(x, call) {
     ## BatchJobs does not return errors
     structure(x, class = c("remote_error", "bperror", "condition"),
-              traceback = capture.output(traceback(call))) 
+              traceback = capture.output(traceback(call)))
 }
 
 .error <- function(msg, class=NULL) {
@@ -113,7 +120,7 @@ bptry <- function(expr, ..., bplist_error, bperror)
 
 .error_remote <- function(x, call) {
     structure(x, class = c("remote_error", "bperror", "error", "condition"),
-              traceback = capture.output(traceback(call))) 
+              traceback = capture.output(traceback(call)))
 }
 
 .error_unevaluated <- function()

--- a/R/bplapply-methods.R
+++ b/R/bplapply-methods.R
@@ -42,6 +42,8 @@ setMethod("bplapply", c("ANY", "list"),
     ## - .send_to, .recv_any, .send, .recv, .close
     FUN <- match.fun(FUN)
 
+    BPREDO <- bperror(BPREDO)
+
     if (!length(X))
         return(.rename(list(), X))
 

--- a/R/bpvec-methods.R
+++ b/R/bpvec-methods.R
@@ -1,5 +1,5 @@
 ### =========================================================================
-### bpvec methods 
+### bpvec methods
 ### -------------------------------------------------------------------------
 
 ## bpvec() dispatches to bplapply() where errors and logging are
@@ -13,6 +13,8 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
 
     FUN <- match.fun(FUN)
     AGGREGATE <- match.fun(AGGREGATE)
+
+    BPREDO <- bperror(BPREDO)
 
     if (!bpschedule(BPPARAM)) {
         param <- as(BPPARAM, "SerialParam")

--- a/inst/unitTests/test_errorhandling.R
+++ b/inst/unitTests/test_errorhandling.R
@@ -148,7 +148,7 @@ test_BPREDO <- function()
 
             ## data not fixed
             res2 <- tryCatch({
-                bplapply(x, f, BPPARAM=param, BPREDO=result)
+                bplapply(x, f, BPPARAM=param, BPREDO=res)
             }, error=identity)
             checkTrue(is(res2, "bplist_error"))
             result <- attr(res2, "result")
@@ -159,7 +159,7 @@ test_BPREDO <- function()
             Sys.sleep(0.25)
 
             ## data fixed
-            res3 <- bplapply(x.fix, f, BPPARAM=param, BPREDO=result)
+            res3 <- bplapply(x.fix, f, BPPARAM=param, BPREDO=res2)
             checkIdentical(as.list(sqrt(1:3)), res3)
             closeAllConnections()
             Sys.sleep(0.25)
@@ -196,7 +196,7 @@ test_bpvec_BPREDO <- function()
             Sys.sleep(0.25)
 
             ## data not fixed
-            res2 <- bptry(bpvec(x, f, BPPARAM=param, BPREDO=result),
+            res2 <- bptry(bpvec(x, f, BPPARAM=param, BPREDO=res),
                           bplist_error=identity)
             checkTrue(is(res2, "bplist_error"))
             result <- attr(res2, "result")
@@ -206,7 +206,7 @@ test_bpvec_BPREDO <- function()
             Sys.sleep(0.25)
 
             ## data fixed
-            res3 <- bpvec(x, sqrt, BPPARAM=param, BPREDO=result)
+            res3 <- bpvec(x, sqrt, BPPARAM=param, BPREDO=res2)
             checkIdentical(sqrt(x), res3)
             closeAllConnections()
             Sys.sleep(0.25)

--- a/man/bperror.Rd
+++ b/man/bperror.Rd
@@ -1,0 +1,42 @@
+\name{bperror}
+
+\alias{bperror}
+
+\title{Accessing task results}
+
+\description{
+
+  This function is used to access the task results and errors from
+  \code{bplapply()} and friends when an error is captured by \code{trycatch()}
+  and returned to the user.
+}
+
+\usage{
+bperror(x)
+}
+
+\arguments{
+  \item{x}{ A \code{bplist_error} object}
+}
+
+\value{
+
+  If \code{x} is of the class \code{bplist_error}, a list of task results. Otherwise, the object \code{x} itself.
+
+}
+
+\author{Martin Morgan \email{martin.morgan@roswellpark.org}}
+
+
+\seealso{
+  \code{\link{tryCatch}}, \code{\link{bptry}}, \code{\link{bplapply}}.
+}
+\examples{
+param = registered()[[1]]
+param
+X = list(1, "2", 3)
+res = tryCatch(bplapply(X, sqrt), error = identity)  # catch the error
+bperror(res)  # access the task results
+}
+
+\keyword{manip}

--- a/vignettes/Errors_Logs_And_Debugging.Rnw
+++ b/vignettes/Errors_Logs_And_Debugging.Rnw
@@ -75,7 +75,7 @@ completion of the entire operation. Thus
 <<messages, eval = FALSE>>=
 res <- bplapply(1:2, function(i) { message(i); Sys.sleep(3) })
 @
-%% 
+%%
 reports messages only after the entire \Rcode{bplapply()} is
 complete.
 
@@ -87,7 +87,7 @@ res <- bplapply(1:2, function(i) {
     message(i)
     Sys.sleep(3)
 })
-@ 
+@
 %%
 This could be confusing when multiple workers write messages at the
 same time --the messages will be interleaved in an arbitrary way -- or
@@ -131,8 +131,8 @@ param <- SnowParam(3, tasks = length(X), stop.on.error = TRUE)
 
 Tasks 1, 2, and 3 are assigned to the three workers, and are
 evaluated. Task 2 fails, stopping further computation. All
-successfully completed tasks are returned as the `result'
-attribute. Usually, this means that the results of tasks 1, 2, and 3
+successfully completed tasks are returned and can be accessed by `bperror`.
+Usually, this means that the results of tasks 1, 2, and 3
 will be returned.
 
 <<errors_6tasksA_stopOnError_output>>=
@@ -140,7 +140,7 @@ res <- tryCatch({
     bplapply(X, sqrt, BPPARAM = param)
 }, error=identity)
 res
-attr(res, "result")
+bperror(res)
 @
 
 Using \Rcode{stop.on.error=FALSE}, all tasks are evaluated.
@@ -152,7 +152,7 @@ res <- tryCatch({
     bplapply(X, sqrt, BPPARAM = param)
 }, error=identity)
 res
-attr(res, "result")
+bperror(res)
 @
 
 \Rcode{bptry()} is a convenient way of trying to evaluate a


### PR DESCRIPTION
Allow `bplist_error` object to be used directly as the argument of `BPREDO`, for example
```
f = sqrt
x = list(1, "2", 3)
x.fix = list(1, 2, 3)

res <- tryCatch(bplapply(x, f), error=identity)
bplapply(x.fix, f, BPREDO=res)
```