### PR TITLE
make BPREDO reproducible

### DIFF
--- a/R/bpinit.R
+++ b/R/bpinit.R
@@ -66,7 +66,10 @@
     }
 
     if (!all(bpok(res))) {
-        attr(res, "BPREDOSEED") <- BPREDOSEED
+        ## attach the seed only when no
+        ## BPREDO presents
+        if (!length(BPREDO))
+            attr(res, "BPREDOSEED") <- BPREDOSEED
     } else {
         attr(res, "BPREDOSEED") <- NULL
     }

--- a/R/bpinit.R
+++ b/R/bpinit.R
@@ -1,5 +1,5 @@
 .bpinit <-
-    function(manager, FUN, BPPARAM, ...)
+    function(manager, FUN, BPPARAM, BPREDO = list(), ...)
 {
     if (!bpisup(BPPARAM)) {
         ## start cluster.
@@ -30,6 +30,19 @@
         on.exit(bpstop(BPPARAM), TRUE, FALSE)
     }
 
+    ## record the initial seed used by the BPPARAM
+    BPREDOSEED <- .RNGstream(BPPARAM)
+
+    ## If BPREDO present and contains a seed, we need to
+    ## 1. use the seed from BPREDO
+    ## 2. recover the old seed after computing the result
+    if (length(BPREDO) && !is.null(attr(BPREDO, "BPREDOSEED"))) {
+        .RNGstream(BPPARAM) <- attr(BPREDO, "BPREDOSEED")
+        on.exit({
+            .RNGstream(BPPARAM) <- BPREDOSEED
+        }, TRUE, after = FALSE)
+    }
+
     ## FUN
     FUN <- .composeTry(
         FUN, bplog(BPPARAM), bpstopOnError(BPPARAM),
@@ -44,6 +57,20 @@
         BPPARAM = BPPARAM,
         ...
     )
+
+    if (length(BPREDO)) {
+        redo_idx <- which(!bpok(BPREDO))
+        if (length(redo_idx))
+            BPREDO[redo_idx] <- res
+        res <- BPREDO
+    }
+
+    if (!all(bpok(res))) {
+        attr(res, "BPREDOSEED") <- BPREDOSEED
+    } else {
+        attr(res, "BPREDOSEED") <- NULL
+    }
+
     res
 }
 

--- a/R/bplapply-methods.R
+++ b/R/bplapply-methods.R
@@ -51,7 +51,7 @@ setMethod("bplapply", c("ANY", "list"),
         compute_element <- which(redo_index)
         X <- X[compute_element]
     } else {
-        compute_element <- NULL
+        compute_element <- seq_along(X)
     }
     nms <- names(X)
 
@@ -66,19 +66,12 @@ setMethod("bplapply", c("ANY", "list"),
         X = X,
         FUN = FUN,
         ARGS = ARGS,
-        BPPARAM = BPPARAM
+        BPPARAM = BPPARAM,
+        BPREDO = BPREDO
     )
 
-    if (length(compute_element)) {
-        BPREDO[compute_element] <- res
-        res <- BPREDO
-    }
-
-    if (!is.null(res)) {
-        if (is.null(compute_element))
-            compute_element <- seq_along(res)
+    if (!is.null(res))
         names(res)[compute_element] <- nms
-    }
 
     if (!all(bpok(res)))
         stop(.error_bplist(res))

--- a/inst/unitTests/test_rng.R
+++ b/inst/unitTests/test_rng.R
@@ -298,6 +298,24 @@ test_rng_global_and_RNGseed_independent <- function() {
     }
     result <- unlist(bplapply(1:11, FUN1, BPREDO = result, BPPARAM = param))
     checkIdentical(result, target)
+
+
+    bpstart(param)
+    target1 <- unlist(bplapply(1:11, FUN, BPPARAM = param))
+    target2 <- unlist(bplapply(1:11, FUN, BPPARAM = param))
+    target3 <- unlist(bplapply(1:11, FUN, BPPARAM = param))
+    bpstop(param)
+
+    bpstart(param)
+    result1 <- bptry(bplapply(1:11, FUN0, BPPARAM = param))
+    result1_redo1 <- unlist(bplapply(1:11, FUN1, BPREDO = result1, BPPARAM = param))
+    result2 <- unlist(bplapply(1:11, FUN, BPPARAM = param))
+    result1_redo2 <- unlist(bplapply(1:11, FUN1, BPREDO = result1, BPPARAM = param))
+    result3 <- unlist(bplapply(1:11, FUN, BPPARAM = param))
+    checkIdentical(target1, result1_redo1)
+    checkIdentical(target1, result1_redo2)
+    checkIdentical(target2, result2)
+    checkIdentical(target3, result3)
 }
 
 test_rng_bpredo <- function()


### PR DESCRIPTION
The current BPREDO does not handle the rng seed stream correctly and the result will not be reproducible. For example
```
FUN <- function(i) rnorm(1)
FUN0 <- function(i) {
    if (identical(i, 7L)) {
        stop("i == 7")
    } else rnorm(1)
}

param <- SerialParam(RNGseed = 123, stop.on.error = FALSE)
bpstart(param)
target <- unlist(bplapply(1:11, FUN, BPPARAM = param))
bpstop(param)

bpstart(param)
## Something is wrong here
result <- bptry(bplapply(1:11, FUN0, BPPARAM = param))
## redo the apply function
result_redo <- unlist(bplapply(1:11, FUN, BPREDO = result, BPPARAM = param))

## the result is not the same as the user expect
identical(result_redo, target)
```
This pull request fixes the issue by attaching the initial seed stream used by BPPARAM to the erroneous result and recover the stream when `BPREDO` is used. Also, if `BPREDO` is presented, the seed stream will not be iterated after the apply function.

