### PR TITLE
attach `BPREDOSEED` to the result only when the attribute does not exist

### DIFF
--- a/R/bpinit.R
+++ b/R/bpinit.R
@@ -73,7 +73,8 @@
     }
 
     if (!all(bpok(res))) {
-        attr(res, "BPREDOSEED") <- BPREDOSEED
+        if(is.null(attr(res, "BPREDOSEED")))
+            attr(res, "BPREDOSEED") <- BPREDOSEED
     } else {
         attr(res, "BPREDOSEED") <- NULL
     }


### PR DESCRIPTION
Hi Martin, this is the one that is left in the previous pull request. We should not attach `BPREDOSEED` to the result when the result contains the attribute BPREDOSEED.  Otherwise, it can overwrite the existing `BPREDOSEED`.

Best,
Jiefei