### PR TITLE
[Bioc 3.15] Implementing the 6-layer model for the apply function

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -120,5 +120,8 @@ export(
     .send_to, .recv_any, .send, .recv, .close, .send_all, .recv_all,
     .bpstart_impl, .bpstop_impl, .bpworker_impl,
     .bplapply_impl, .bpiterate_impl,
-    .error_worker_comm
+    .error_worker_comm,
+    .manager, .manager_send,
+    .manager_recv, .manager_capacity,
+    .manager_flush, .manager_cleanup
 )

--- a/R/BatchJobsParam-class.R
+++ b/R/BatchJobsParam-class.R
@@ -115,7 +115,7 @@ setMethod("bplapply", c("ANY", "BatchJobsParam"),
         return(bplapply(X, FUN, ..., BPPARAM=SerialParam()))
 
     idx <- .redo_index(X, BPREDO)
-    if (any(idx))
+    if (length(idx))
         X <- X[idx]
     nms <- names(X)
 
@@ -168,7 +168,7 @@ setMethod("bplapply", c("ANY", "BatchJobsParam"),
     ## post-process
     names(res) <- nms
 
-    if (any(idx)) {
+    if (length(BPREDO) && length(idx)) {
         BPREDO[idx] <- res
         res <- BPREDO
     }

--- a/R/BatchtoolsParam-class.R
+++ b/R/BatchtoolsParam-class.R
@@ -358,7 +358,7 @@ setMethod("bplapply", c("ANY", "BatchtoolsParam"),
         X <- as.list(X)
 
     idx <- .redo_index(X, BPREDO)
-    if (any(idx))
+    if (length(idx))
         X <- X[idx]
     nms <- names(X)
 
@@ -431,7 +431,7 @@ setMethod("bplapply", c("ANY", "BatchtoolsParam"),
     if (!is.null(res))
         names(res) <- nms
 
-    if (any(idx)) {
+    if (length(BPREDO) && length(idx)) {
         BPREDO[idx] <- res
         res <- BPREDO
     }

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -70,7 +70,7 @@ setMethod("bplapply", c("ANY", "DoparParam"),
     FUN <- match.fun(FUN)
 
     idx <- .redo_index(X, BPREDO)
-    if (any(idx))
+    if (length(idx))
         X <- X[idx]
 
     FUN <- .composeTry(
@@ -100,9 +100,9 @@ setMethod("bplapply", c("ANY", "DoparParam"),
 
     names(res) <- names(X)
 
-    if (any(idx)) {
+    if (length(BPREDO) && length(idx)) {
         BPREDO[idx] <- res
-        res <- BPREDO 
+        res <- BPREDO
     }
 
     if (!all(bpok(res)))

--- a/R/bpinit.R
+++ b/R/bpinit.R
@@ -62,15 +62,9 @@
         manager, # dispatch
         FUN = FUN,
         BPPARAM = BPPARAM,
+        BPREDO = BPREDO,
         ...
     )
-
-    if (length(BPREDO)) {
-        redo_idx <- which(!bpok(BPREDO))
-        if (length(redo_idx))
-            BPREDO[redo_idx] <- res
-        res <- BPREDO
-    }
 
     if (!all(bpok(res))) {
         ## attach the seed only when no BPREDO presents

--- a/R/bplapply-methods.R
+++ b/R/bplapply-methods.R
@@ -45,19 +45,6 @@ setMethod("bplapply", c("ANY", "list"),
     if (!length(X))
         return(.rename(list(), X))
 
-    ## which need to be redone?
-    redo_index <- .redo_index(X, BPREDO)
-    if (any(redo_index)) {
-        compute_element <- which(redo_index)
-        X <- X[compute_element]
-    } else {
-        compute_element <- seq_along(X)
-    }
-    nms <- names(X)
-
-    ## split into tasks
-    X <- .splitX(X, bpnworkers(BPPARAM), bptasks(BPPARAM), redo_index)
-
     ARGS <- list(...)
 
     manager <- structure(list(), class="lapply") # dispatch
@@ -70,11 +57,9 @@ setMethod("bplapply", c("ANY", "list"),
         BPREDO = BPREDO
     )
 
-    if (!is.null(res))
-        names(res)[compute_element] <- nms
-
-    if (!all(bpok(res)))
+    if (!all(bpok(res))) {
         stop(.error_bplist(res))
+    }
 
     res
 }

--- a/R/bpvec-methods.R
+++ b/R/bpvec-methods.R
@@ -29,14 +29,12 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
     on.exit(bptasks(BPPARAM) <- otasks)
 
     idx <- .redo_index(si, BPREDO)
-    if (any(idx))
-        si <- si[idx]
 
     ## FIXME: 'X' sent to all workers, but ith worker only needs X[i]
     FUN1 <- function(i, ...) FUN(X[i], ...)
-    res <- bptry(bplapply(si, FUN1, ..., BPREDO=BPREDO[idx], BPPARAM=BPPARAM))
+    res <- bptry(bplapply(si, FUN1, ..., BPREDO=BPREDO, BPPARAM=BPPARAM))
 
-    if (any(idx)) {
+    if (length(BPREDO) && length(idx)) {
         BPREDO[idx] <- res
         res <- BPREDO
     }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -65,96 +65,36 @@
     }
 }
 
-.split_X_redo <-
-    function(X, redo_index, elements_per_task, n)
+.ntask <-
+    function(X, workers, tasks)
 {
-    ## Whether we need to calculate n?
-    prealloc <- missing(n)
-    splittedX <- vector("list", ifelse(prealloc, 0L, n))
-    last_redo_status <- redo_index[[1]]
-    task_i <- 1L
-    x_start <- 1L
-    x_len <- 0L
-    for (i in seq_along(redo_index)) {
-        redo <- redo_index[[i]]
-        ## The task division depends on two factors:
-        ## 1. Whether the current redo is different from the previous one?
-        ## 2. Whether the elements number in a task will exceed
-        ##    `elements_per_task` limit
-        is_switch <- xor(last_redo_status, redo)
-        is_switch <- ifelse(
-            is_switch || !redo, is_switch, x_len >= elements_per_task
-        )
-        ## If we want to split X at this position and it is not in the
-        ## preallocation stage, we create a subset of X or
-        ## .bploop_rng_iter based on the previous redo value
-        if (!prealloc && is_switch) {
-            if (last_redo_status)
-                splittedX[[task_i]] <- X[seq.int(x_start, length.out = x_len)]
-            else
-                splittedX[[task_i]] <- .bploop_rng_iter(x_len)
-        }
-        ## if we split X, record the next redo status, start index,
-        ## add task index by 1 and reset the length, otherwise we just
-        ## add the length by 1
-        if (is_switch) {
-            x_start <- ifelse(last_redo_status, x_start + x_len, x_start)
-            last_redo_status <- redo
-            task_i <- task_i + 1L
-            x_len <- 1L
-        } else {
-            x_len <- x_len + 1
-        }
-        if (!prealloc && task_i >= n)
-            break
-    }
-    ## The last task does not have the "switch" so we need to manually add it
-    if (!prealloc && last_redo_status) {
-        splittedX[[task_i]] <- X[seq.int(x_start, length(X))]
-    }
-
-    if (prealloc) {
-        task_i - !last_redo_status
+    if (tasks == 0L) {
+        workers
     } else {
-        splittedX
+        min(length(X), tasks)
     }
 }
 
-.splitX <-
-    function(X, workers, tasks, redo_index = NULL)
+.splitX <- function(X, workers, tasks)
 {
-    if (tasks == 0L) {
-        tasks <- workers
-    } else {
-        tasks <- min(length(X), tasks)
-    }
-    ## If redo index presents, split X based on the index while
-    ## preserving the correct rng stream.  it will respect `tasks`
-    ## value
-    if (length(redo_index)) {
-        ## Two-pass algorithm, the first pass calculate the required
-        ## list size to allocate, then do the real allocation
-        elements_per_task <- ceiling(length(X) / max(tasks, 1L))
-        n <- .split_X_redo(X, redo_index, elements_per_task)
-        .split_X_redo(X, redo_index, elements_per_task, n)
-    } else {
-        idx <- .splitIndices(length(X), tasks)
-        relist(X, idx)
-    }
-
+    tasks <- .ntask(X, workers, tasks)
+    idx <- .splitIndices(length(X), tasks)
+    relist(X, idx)
 }
 
 .redo_index <-
     function(X, BPREDO)
 {
-    idx <- !bpok(BPREDO)
-    if (length(idx)) {
+    if (length(BPREDO)) {
         if (length(BPREDO) != length(X))
             stop("'length(BPREDO)' must equal 'length(X)'")
-        if (!any(idx))
+        idx <- which(!bpok(BPREDO))
+        if (!length(idx))
             stop("no previous error in 'BPREDO'")
+        idx
+    } else {
+        seq_along(X)
     }
-    idx
 }
 
 ## re-apply names on X of lapply(X, FUN) to the return value

--- a/inst/unitTests/test_bploop.R
+++ b/inst/unitTests/test_bploop.R
@@ -47,3 +47,34 @@ test_reducer_5 <- function() {
     checkIdentical(10, { r$add(3, list(3)); r$value() })
     checkIdentical(TRUE, r$isComplete())
 }
+
+test_bploop_lapply_iter  <- function() {
+    .bploop_lapply_iter <- BiocParallel:::.bploop_lapply_iter
+    .bploop_rng_iter <- BiocParallel:::.bploop_rng_iter
+
+    X <- 1:10
+    redo_index <- c(1:2,6:8)
+    iter <- .bploop_lapply_iter(X, redo_index, 10)
+    checkIdentical(iter(), 1:2)
+    checkIdentical(iter(), .bploop_rng_iter(3L))
+    checkIdentical(iter(), 6:8)
+    checkIdentical(iter(), list(NULL))
+    checkIdentical(iter(), list(NULL))
+
+    iter <- .bploop_lapply_iter(X, redo_index, 2)
+    checkIdentical(iter(), 1:2)
+    checkIdentical(iter(), .bploop_rng_iter(3L))
+    checkIdentical(iter(), 6:7)
+    checkIdentical(iter(), 8L)
+    checkIdentical(iter(), list(NULL))
+    checkIdentical(iter(), list(NULL))
+
+    redo_index <- 6:8
+    iter <- .bploop_lapply_iter(X, redo_index, 1)
+    checkIdentical(iter(), .bploop_rng_iter(5L))
+    checkIdentical(iter(), 6L)
+    checkIdentical(iter(), 7L)
+    checkIdentical(iter(), 8L)
+    checkIdentical(iter(), list(NULL))
+    checkIdentical(iter(), list(NULL))
+}

--- a/inst/unitTests/test_utilities.R
+++ b/inst/unitTests/test_utilities.R
@@ -38,97 +38,16 @@ test_splitX <- function()
     checkIdentical(as.list(X),               .splitX(X, 2, 4))
 }
 
-test_splitX_with_redo <- function(){
-    .split_X_redo <- BiocParallel:::.split_X_redo
-    .bploop_rng_iter <- BiocParallel:::.bploop_rng_iter
-
-    N <- 6
-    X <- 1:N
-
-
-    task_size <- 1L
-    redo_index <- rep(TRUE, N)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(splittedX, as.list(X))
-
-    task_size <- 4L
-    redo_index <- rep(TRUE, N)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(splittedX, list(1:4, 5:6))
-
-    task_size <- 1L
-    redo_index <- c(TRUE, FALSE, TRUE, TRUE, TRUE, FALSE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(1L, .bploop_rng_iter(1L),
-             3L, 4L, 5L)
-    )
-
-    task_size <- 2L
-    redo_index <- c(TRUE, FALSE, TRUE, TRUE, TRUE, FALSE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(1L, .bploop_rng_iter(1L),
-             3L:4L, 5L)
-    )
-
-    task_size <- 10L
-    redo_index <- c(TRUE, FALSE, TRUE, TRUE, TRUE, FALSE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(1L, .bploop_rng_iter(1L),
-             3L:5L)
-    )
-
-    task_size <- 1L
-    redo_index <- c(FALSE, FALSE, TRUE, FALSE, FALSE, FALSE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(.bploop_rng_iter(2L),
-             3L)
-    )
-
-    task_size <- 1L
-    redo_index <- c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(.bploop_rng_iter(2L),
-             3L, 4L, 5L, 6L)
-    )
-
-    task_size <- 3L
-    redo_index <- c(FALSE, FALSE, TRUE, TRUE, TRUE, TRUE)
-    n <- .split_X_redo(X[redo_index], redo_index, task_size)
-    splittedX <- .split_X_redo(X[redo_index], redo_index, task_size, n)
-    checkIdentical(
-        splittedX,
-        list(.bploop_rng_iter(2L),
-             3:5, 6L)
-    )
-}
-
 test_redo_index <- function() {
     .redo_index <- BiocParallel:::.redo_index
     err <- BiocParallel:::.error("")
-    checkIdentical(logical(), .redo_index(list(), list()))
-    checkIdentical(TRUE, .redo_index(list(1), list(err)))
-    checkIdentical(c(FALSE, TRUE), .redo_index(list(1, "2"), list(1, err)))
+    checkIdentical(integer(), .redo_index(list(), list()))
+    checkIdentical(1L, .redo_index(list(1), list(err)))
+    checkIdentical(2L, .redo_index(list(1, "2"), list(1, err)))
     ## all need recalculating
-    checkIdentical(c(TRUE, TRUE), .redo_index(list("1", "2"), list(err, err)))
+    checkIdentical(1:2, .redo_index(list("1", "2"), list(err, err)))
     ## X can be a vector
-    checkIdentical(c(FALSE, TRUE), .redo_index(1:2, list(1, err)))
+    checkIdentical(2L, .redo_index(1:2, list(1, err)))
     ## lengths differ
     checkException(.redo_index(list(1, 2), list(err)), silent=TRUE)
     ## no previous error

--- a/man/DeveloperInterface.Rd
+++ b/man/DeveloperInterface.Rd
@@ -20,6 +20,20 @@
 \alias{.close}
 \alias{.close,ANY-method}
 
+
+\alias{.manager}
+\alias{.manager,ANY-method}
+\alias{.manager_send}
+\alias{.manager_send,ANY-method}
+\alias{.manager_recv}
+\alias{.manager_recv,ANY-method}
+\alias{.manager_flush}
+\alias{.manager_flush,ANY-method}
+\alias{.manager_cleanup}
+\alias{.manager_cleanup,ANY-method}
+\alias{.manager_capacity}
+\alias{.manager_capacity,ANY-method}
+
 \alias{.bpstart_impl}
 \alias{.bpstop_impl}
 \alias{.bpworker_impl}
@@ -55,6 +69,14 @@
 .recv(worker)
 .close(worker)
 
+## optional task manager
+.manager(backend)
+.manager_send(manager, value)
+.manager_recv(manager)
+.manager_capacity(manager)
+.manager_flush(manager)
+.manager_cleanup(manager)
+
 ## supporting implementations
 
 .bpstart_impl(x)
@@ -79,6 +101,10 @@
   \item{backend}{
     An object containing information about the cluster, returned by
     \code{bpbackend(<BPPARAM>)}.
+  }
+
+  \item{manager}{
+    An object returned by \code{.manager()}
   }
 
   \item{worker}{
@@ -170,6 +196,16 @@
   the \code{length(cluster)}, invoking \code{.send_to()} or
   \code{.recv_any()} on each iteration.
 
+  The task manager is an optional interface for the backend who wants
+  to have a control over the task dispatching process.
+  \code{.manager_send()} sends the task value to a worker, \code{.manager_recv()}
+  returns a list with each element being a result received from a worker.
+  \code{.manager_capacity()} instructs how many
+  tasks values can be processed simultaneously by the cluster. \code{.manager_flush()}
+  flushes all the cached tasks(if any) immediately. \code{.manager_cleanup()} performs
+  the cleanup after the job is finished. The default methods for
+  \code{.manager_flush()} and \code{.manager_cleanup()} are no-op.
+
 }
 
 \value{
@@ -181,6 +217,9 @@
   All \code{send*} and \code{recv*} functions are endomorphic, returning a
   \code{cluster} object.
 
+  The return value of \code{.manager_recv()} is a list with each element being
+  a result received from a worker, \code{.manager_capacity()} is
+  an integer. The return values of the other \code{.manager_*()} are not restricted
 }
 
 \examples{

--- a/man/bploop.Rd
+++ b/man/bploop.Rd
@@ -1,7 +1,7 @@
 \name{bploop}
 \Rdversion{1.1}
 
-% Class 
+% Class
 \alias{bploop}
 
 % managers
@@ -22,7 +22,7 @@
 }
 
 \usage{
-\S3method{bploop}{lapply}(manager, X, FUN, ARGS, BPPARAM, ...)
+\S3method{bploop}{lapply}(manager, X, FUN, ARGS, BPPARAM, BPREDO, ...)
 
 \S3method{bploop}{iterate}(manager, ITER, FUN, ARGS, BPPARAM,
        REDUCE, init, reduce.in.order, ...)
@@ -54,6 +54,9 @@
     reduction must occur in the order jobs are dispatched
     (\code{TRUE}) or that reduction can occur in the order jobs are
     completed (\code{FALSE}).}
+
+  \item{BPREDO}{(Optional) A \code{list} of output from \code{bplapply}
+   or \code{bpiterate} with one or more failed elements.}
 
   \item{\ldots}{Additional arguments, ignored in all cases.}
 


### PR DESCRIPTION
This pull request follows the pull roadmap in https://github.com/Bioconductor/BiocParallel/pull/162 and implements the 6-layer model for the apply function. The changes include:

1. The function `.bploop_lapply_iter` is revised such that there is no need to split `X` in advance, the argument `X` for `FUN` will be generated on demand.  
2. `.redo_index` will return the index of `X` instead of a logical vector. 
3. A minor bug fix for the missing log and result issue when a worker error occurs.

Best,
Jiefei