### PR TITLE
fix the message sink issue for the SerialParam

### DIFF
--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -89,6 +89,7 @@ setMethod(
     function(x, ...)
 {
     x$backend <- .SerialBackend()
+    x$backend$BPPARAM <- x
     .bpstart_impl(x)
 })
 
@@ -143,7 +144,7 @@ setMethod(
     if (inherits(msg, "error"))
         stop(msg)
     if (msg$type == "EXEC") {
-        value <- .bpworker_EXEC(msg)
+        value <- .bpworker_EXEC(msg, bplog(backend$BPPARAM))
         list(node = 1L, value = value)
     }
 })

--- a/R/SnowParam-utils.R
+++ b/R/SnowParam-utils.R
@@ -30,7 +30,7 @@ bprunMPIworker <- function() {
 .bpfork <- function (nnodes, timeout, host, port)
 {
     nnodes <- as.integer(nnodes)
-    if (is.na(nnodes) || nnodes < 1L) 
+    if (is.na(nnodes) || nnodes < 1L)
         stop("'nnodes' must be >= 1")
 
     if (length(host) != 1L || is.na(host) || !is.character(host))
@@ -96,10 +96,12 @@ bprunMPIworker <- function() {
         )
     }
     if (!is.null(con)) {
+        on.exit({
+            sink(NULL, type = "message")
+            sink(NULL, type = "output")
+        })
         sink(con, type = "message")
         sink(con, type = "output")
-        .log_internal()    
-        sink(NULL, type = "message")
-        sink(NULL, type = "output")
+        .log_internal()
     } else .log_internal()
 }

--- a/inst/unitTests/test_errorhandling.R
+++ b/inst/unitTests/test_errorhandling.R
@@ -53,7 +53,7 @@ test_SerialParam_stop.on.error <- function()
     checkException(bplapply(X, sqrt, BPPARAM=p), silent=TRUE)
     current <- tryCatch(bplapply(X, sqrt, BPPARAM=p), error=identity)
     checkTrue(is(current, "bplist_error"))
-    target <- "BiocParallel errors\n  1 remote errors, element index: 2\n  1 unevaluated and other errors\n  first remote error: non-numeric argument to mathematical function"
+    target <- "BiocParallel errors\n  1 remote errors, element index: 2\n  1 unevaluated and other errors\n  first remote error:\nError in FUN(...): non-numeric argument to mathematical function\n"
     checkIdentical(target, conditionMessage(current))
     target <- tryCatch(lapply(X, sqrt), error=identity)
     checkIdentical(


### PR DESCRIPTION
This fixes the `SerialParam` issue in https://github.com/Bioconductor/BiocParallel/issues/168. An `on.exit` handler is added to stop sinking when the function quits. A raw connection is used as suggested by [@HenrikBengtsson ](https://github.com/Bioconductor/BiocParallel/issues/168#issuecomment-964157599)