### PR TITLE
remove the empty string from the worker output

### DIFF
--- a/R/bploop.R
+++ b/R/bploop.R
@@ -52,10 +52,12 @@
     })
     t2 <- proc.time()
 
-    if (sink.sout)
+    if (sink.sout) {
         sout <- rawToChar(rawConnectionValue(file))
-    else
+        if (!nchar(sout)) sout <- NULL
+    } else {
         sout <- NULL
+    }
 
     success <- !(inherits(value, "bperror") || !all(bpok(value)))
     log <- .log_buffer_get()


### PR DESCRIPTION
By default, `sout <- rawToChar(rawConnectionValue(file))` from the worker code will be an empty string if there is no output. This will make the manager print an empty line. We set `sout` to `NULL` in this case.