### PR TITLE
Allow the progress bar to show the progress of the `bplapply` function

### DIFF
--- a/R/bploop.R
+++ b/R/bploop.R
@@ -242,7 +242,8 @@ bploop.lapply <-
         FUN = FUN,
         ARGS = ARGS,
         BPPARAM =BPPARAM,
-        reduce.in.order = TRUE
+        reduce.in.order = TRUE,
+        pregress.len = length(X)
     )
 }
 
@@ -264,7 +265,7 @@ bploop.lapply <-
 ## - ARGS: the arguments to FUN
 bploop.iterate <-
     function(
-        manager, ITER, FUN, ARGS, BPPARAM, REDUCE, init, reduce.in.order, ...
+        manager, ITER, FUN, ARGS, BPPARAM, REDUCE, init, reduce.in.order, pregress.len, ...
     )
 {
     cl <- bpbackend(BPPARAM)
@@ -276,9 +277,9 @@ bploop.iterate <-
     running <- logical(workers)
     reducer <- .reducer(REDUCE, init, reduce.in.order)
 
-    progress <- .progress(active=bpprogressbar(BPPARAM), iterate=TRUE)
+    progress <- .progress(active=bpprogressbar(BPPARAM), iterate=missing(pregress.len))
     on.exit(progress$term(), TRUE)
-    progress$init()
+    progress$init(pregress.len)
 
     ARGFUN <- function(X, seed)
         c(

--- a/man/bploop.Rd
+++ b/man/bploop.Rd
@@ -25,7 +25,7 @@
 \S3method{bploop}{lapply}(manager, X, FUN, ARGS, BPPARAM, ...)
 
 \S3method{bploop}{iterate}(manager, ITER, FUN, ARGS, BPPARAM,
-       REDUCE, init, reduce.in.order, ...)
+       REDUCE, init, reduce.in.order, pregress.len, ...)
 }
 
 \arguments{
@@ -56,7 +56,8 @@
     completed (\code{FALSE}).}
 
   \item{\ldots}{Additional arguments, ignored in all cases.}
-
+  
+  \item{pregress.len}{(Optional) The length of the progress bar}
 }
 
 \details{


### PR DESCRIPTION
This is a quick fix for the issue in https://github.com/Bioconductor/BiocParallel/issues/172. Note that for making the progress bar fully functional, the pull request https://github.com/Bioconductor/BiocParallel/pull/171 must also be merged with the RELEASE_3_14 branch as the empty line from the log will force the progress bar to reprint itself.