### PR TITLE
reset the seed generator type before creating the initial seed

### DIFF
--- a/R/rng.R
+++ b/R/rng.R
@@ -39,6 +39,7 @@
     ## coerces seed to appropriate format for RNGkind; NULL seed (from
     ## bpRNGseed()) uses the global random number stream.
     if (!is.null(seed)) {
+        RNGkind("default", "default", "default")
         set.seed(seed)
 
         ## change kind


### PR DESCRIPTION
The initial seed generator can be messed up by the user's code. For example

```
> ## This is what we expect
> RNGkind("default", "default", "default")
> .rng_init_stream(1)
[1]       10407 -1535484873  1222746892  1963142301   158053050 -1240755981  -292394600

> ## This can be the reality...
> RNGkind("L'Ecuyer-CMRG")
> .rng_init_stream(1)
[1]       10407   481710355 -1859132616 -1793405991 -1901575738   165263759 -1420502396
```
To fix this issue, we reset the type of the seed generator before we generate the initial seed.