### PR TITLE
implement the task cache for the SnowParam

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -127,5 +127,7 @@ export(
     .manager, .manager_send, .manager_recv,
     .manager_send_all, .manager_recv_all,
     .manager_capacity,
-    .manager_flush, .manager_cleanup
+    .manager_flush, .manager_cleanup,
+    .task_type, .EXEC_static,
+    .EXEC_dynamic, .remake_EXEC
 )

--- a/R/DeveloperInterface.R
+++ b/R/DeveloperInterface.R
@@ -1,9 +1,10 @@
 ##
 ## see NAMESPACE section for definitive exports
 ##
+## Manager class
+.TaskManager <- setClass("TaskManager", contains = "environment")
 
 ## server
-
 setGeneric(
     ".send_to",
     function(backend, node, value) standardGeneric(".send_to"),
@@ -51,8 +52,8 @@ setGeneric(
 ## task manager
 setGeneric(
     ".manager",
-    function(backend) standardGeneric(".manager"),
-    signature = "backend"
+    function(BPPARAM) standardGeneric(".manager"),
+    signature = "BPPARAM"
 )
 
 setGeneric(
@@ -171,14 +172,15 @@ setMethod(
 ## default task manager implementation
 setMethod(
     ".manager", "ANY",
-    function(backend)
+    function(BPPARAM)
 {
-    manager <- new.env(parent = emptyenv())
-    manager$backend <- backend
-    availability <- rep(list(TRUE), length(manager$backend))
+    manager <- .TaskManager()
+    manager$BPPARAM <- BPPARAM
+    manager$backend <- bpbackend(BPPARAM)
+    manager$capacity <- length(manager$backend)
+    availability <- rep(list(TRUE), manager$capacity)
     names(availability) <- as.character(seq_along(manager$backend))
     manager$availability <- as.environment(availability)
-    manager$capacity <- length(manager$backend)
     manager
 })
 

--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -368,3 +368,68 @@ setAs("spawnedMPIcluster", "SnowParam",
     .SnowParam(.clusterargs=.clusterargs, cluster=from, .controlled=FALSE,
                workers=length(from))
 })
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### task dispatching interface
+###
+.SOCKmanager <- setClass("SOCKmanager", contains = "TaskManager")
+
+setMethod(
+    ".manager", "SnowParam",
+    function(BPPARAM)
+{
+    manager <- callNextMethod()
+    manager$initialized <- rep(FALSE, manager$capacity)
+    manager <- as(manager, "SOCKmanager")
+    manager
+})
+
+setMethod(
+  ".manager_send", "SOCKmanager",
+  function(manager, value)
+{
+    availability <- manager$availability
+    stopifnot(length(availability) >=0)
+    ## send the job to the next available worker
+    worker <- names(availability)[1]
+    id <- as.integer(worker)
+    ## Do the cache only when the snow worker is
+    ## created by our package.
+    if (.controlled(manager$BPPARAM) && .task_type(value) == "EXEC") {
+        if (manager$initialized[id])
+            value <- .EXEC_dynamic(value)
+        else
+            manager$initialized[id] <- TRUE
+    }
+    .send_to(manager$backend, as.integer(worker), value)
+    rm(list = worker, envir = availability)
+    manager
+})
+
+setMethod(
+    ".manager_cleanup", "SOCKmanager",
+    function(manager)
+{
+    manager <- callNextMethod()
+    manager$initialized <- rep(FALSE, manager$capacity)
+    if (.controlled(manager$BPPARAM)) {
+        value <- .EXEC(tag = NULL, .clean_EXEC_static, args = NULL)
+        .send_all(manager$backend, value)
+        msg <- .recv_all(manager$backend)
+    }
+    manager
+})
+
+## The worker class of SnowParam
+setOldClass(c("SOCK0node", "SOCKnode"))
+setMethod(".recv", "SOCKnode",
+    function(worker)
+{
+    msg <- callNextMethod()
+    if (inherits(msg, "error"))
+      return(msg)
+    ## read/write the static value(if any)
+    if (msg$type == "EXEC")
+      msg <- .load_EXEC_static(msg)
+    msg
+})

--- a/R/SnowParam-utils.R
+++ b/R/SnowParam-utils.R
@@ -106,3 +106,27 @@ bprunMPIworker <- function() {
         .log_internal()
     } else .log_internal()
 }
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### EXEC command cache
+###
+
+## read/write the static value
+.load_EXEC_static <-
+    function(EXEC)
+{
+    static_EXEC <- .EXEC_static(EXEC)
+    if (is.null(static_EXEC)) {
+        static_EXEC <- options("BIOCPARALLEL_STATIC_EXEC")[[1]]
+        .remake_EXEC(EXEC, static_EXEC)
+    } else {
+        options(BIOCPARALLEL_STATIC_EXEC = static_EXEC)
+        EXEC
+    }
+}
+
+.clean_EXEC_static <-
+    function()
+{
+    options(BIOCPARALLEL_STATIC_EXEC = NULL)
+}

--- a/R/TransientMulticoreParam-class.R
+++ b/R/TransientMulticoreParam-class.R
@@ -118,3 +118,9 @@ setMethod(
 {
     stop("'.close,TransientMulticoreParam-method' not implemented")
 })
+
+setMethod(".manager", "TransientMulticoreParam",
+          function(BPPARAM)
+{
+    selectMethod(.manager, "ANY")(BPPARAM)
+})

--- a/R/bploop.R
+++ b/R/bploop.R
@@ -198,8 +198,7 @@
 .bploop_impl <-
     function(ITER, FUN, ARGS, BPPARAM, BPREDO, OPTIONS, reducer, progress.length)
 {
-    cl <- bpbackend(BPPARAM)
-    manager <- .manager(cl)
+    manager <- .manager(BPPARAM)
     on.exit(.manager_cleanup(manager), add = TRUE)
 
     ## worker options
@@ -230,6 +229,7 @@
             X=X , FUN=FUN , ARGS = ARGS,
             OPTIONS = OPTIONS, BPRNGSEED = seed
         )
+    static.args <- c("FUN", "ARGS", "OPTIONS")
 
     total <- 0L
     running <- 0L
@@ -250,8 +250,12 @@
                     warning("first invocation of 'ITER()' returned NULL")
                 break
             }
-            value_ <- .EXEC(total + 1L, .workerLapply, ARGFUN(value, seed))
-            .manager_send(manager, value_)
+            args <- ARGFUN(value, seed)
+            task <- .EXEC(total + 1L, .workerLapply,
+                          args = args,
+                          static.fun = TRUE,
+                          static.args = static.args)
+            .manager_send(manager, task)
             seed <- .rng_iterate_substream(seed, length(value))
             total <- total + 1L
             running <- running + 1L

--- a/R/bpstart-methods.R
+++ b/R/bpstart-methods.R
@@ -68,8 +68,7 @@ setMethod("bpstart", "missing",
 .bpstart_set_logging <-
     function(x)
 {
-    cluster <- bpbackend(x)
-    manager <- .manager(cluster)
+    manager <- .manager(x)
     on.exit({.manager_cleanup(manager)})
 
     value <- .EXEC(NULL, .log_load, list(bplog(x), bpthreshold(x), TRUE))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -189,3 +189,22 @@
     )
     stop(msg, call. = FALSE)
 }
+
+## This is only used for reducing the size of
+## the function in serialization
+funcFactory <-
+    function(funcName)
+{
+    template <-
+        "
+        FUN_ <- function(...) %funcName%(...)
+        environment(FUN_) <- getNamespace('base')
+        FUN_
+        "
+    txt <- gsub("%funcName%", funcName, template ,fixed = TRUE)
+    eval(
+        parse(
+            text=txt
+        )
+    )
+}

--- a/inst/unitTests/test_SnowParam.R
+++ b/inst/unitTests/test_SnowParam.R
@@ -1,12 +1,12 @@
-test_SnowParam_construction <- function() 
+test_SnowParam_construction <- function()
 {
-    checkException(SnowParam(logdir = tempdir())) 
+    checkException(SnowParam(logdir = tempdir()))
 
     p <- MulticoreParam(jobname = 'test')
     checkIdentical(bpjobname(p), 'test')
 }
 
-test_SnowParam_SOCK <- function() 
+test_SnowParam_SOCK <- function()
 {
     if (!requireNamespace("snow", quietly=TRUE))
         DEACTIVATED("'snow' package did not load")
@@ -24,7 +24,7 @@ test_SnowParam_SOCK_character <- function()
     bpstop(bpstart(SnowParam("localhost")))
 }
 
-test_SnowParam_MPI <- function() 
+test_SnowParam_MPI <- function()
 {
     if (.Platform$OS.type == "windows")
         DEACTIVATED("MPI tests not run on Windows")
@@ -67,7 +67,7 @@ test_SnowParam_coerce_from_MPI <- function()
 {
     if (.Platform$OS.type == "windows")
         DEACTIVATED("MPI tests not run on Windows")
-    
+
     if (!requireNamespace("snow", quietly=TRUE) ||
          !requireNamespace("Rmpi", quietly=TRUE))
         DEACTIVATED("'snow' and/or 'Rmpi' package did not load")
@@ -119,4 +119,61 @@ test_SnowParam_bpforceGC <- function() {
     checkIdentical(TRUE, bpforceGC(SnowParam(force.GC = TRUE)))
     checkException(SnowParam(force.GC = NA), silent = TRUE)
     checkException(SnowParam(force.GC = 1:2), silent = TRUE)
+}
+
+.test_cache <- function(msg) {
+    checkIdentical(BiocParallel:::.task_type(msg), "EXEC")
+
+    ## No initial cache
+    msg1 <- BiocParallel:::.load_EXEC_static(msg)
+    checkIdentical(msg, msg1)
+
+    ## Extract the dynamic part of the task
+    msg2 <- BiocParallel:::.EXEC_dynamic(msg)
+    checkTrue(!xor(msg2$static.fun, is.null(msg2$data$fun)))
+    if (length(msg2$static.args))
+        checkTrue(!any(msg2$static.args %in% names(msg2$data$args)))
+    else
+        checkTrue(all(msg2$static.args %in% names(msg2$data$args)))
+
+    ## rebuild the EXEC
+    msg3 <- BiocParallel:::.load_EXEC_static(msg2)
+    checkIdentical(msg$data$tag, msg3$data$tag)
+    checkTrue(!is.null(msg3$data$fun))
+    checkTrue(setequal(msg$data$args, msg3$data$args))
+
+    ## create another different msg
+    msg4 <- BiocParallel:::.EXEC("test", function(x)x,
+                                 args = list(a=1,b=1,c=1),
+                                 static.fun = TRUE,
+                                 static.args = c("a","b")
+    )
+    msg5 <- BiocParallel:::.load_EXEC_static(msg4)
+    checkIdentical(msg5, msg4)
+}
+
+test_SnowParam_taskCache <- function() {
+    msg1 <- BiocParallel:::.EXEC("mytag1", identity,
+                                 args = list(a=1,b=2,c=3)
+    )
+    .test_cache(msg1)
+
+    msg2 <- BiocParallel:::.EXEC("mytag2", identity,
+                                 args = list(a=1,b=2,c=3),
+                                 static.fun = TRUE
+    )
+    .test_cache(msg2)
+
+    msg3 <- BiocParallel:::.EXEC("mytag3", identity,
+                                 args = list(a=1,b=2,c=3),
+                                 static.fun = TRUE,
+                                 static.args = c("a","b")
+    )
+    .test_cache(msg3)
+
+    msg4 <- BiocParallel:::.EXEC("mytag", identity,
+                                 args = NULL,
+                                 static.fun = TRUE
+    )
+    .test_cache(msg4)
 }

--- a/man/DeveloperInterface.Rd
+++ b/man/DeveloperInterface.Rd
@@ -17,32 +17,50 @@
 \alias{.send,ANY-method}
 \alias{.recv}
 \alias{.recv,ANY-method}
+\alias{.recv,SOCKnode-method}
 \alias{.close}
 \alias{.close,ANY-method}
 
 
 \alias{.manager}
 \alias{.manager,ANY-method}
+\alias{.manager,SnowParam-method}
+\alias{.manager,TransientMulticoreParam-method}
 \alias{.manager_send}
 \alias{.manager_send,ANY-method}
+\alias{.manager_send,TaskManager-method}
+\alias{.manager_send,SOCKmanager-method}
 \alias{.manager_recv}
 \alias{.manager_recv,ANY-method}
+\alias{.manager_recv,TaskManager-method}
 \alias{.manager_send_all}
 \alias{.manager_send_all,ANY-method}
+\alias{.manager_send_all,TaskManager-method}
 \alias{.manager_recv_all}
 \alias{.manager_recv_all,ANY-method}
+\alias{.manager_recv_all,TaskManager-method}
 \alias{.manager_flush}
 \alias{.manager_flush,ANY-method}
+\alias{.manager_flush,TaskManager-method}
 \alias{.manager_cleanup}
 \alias{.manager_cleanup,ANY-method}
+\alias{.manager_cleanup,TaskManager-method}
+\alias{.manager_cleanup,SOCKmanager-method}
 \alias{.manager_capacity}
 \alias{.manager_capacity,ANY-method}
+\alias{.manager_capacity,TaskManager-method}
 
 \alias{.bpstart_impl}
 \alias{.bpstop_impl}
 \alias{.bpworker_impl}
 \alias{.bplapply_impl}
 \alias{.bpiterate_impl}
+
+
+\alias{.task_type}
+\alias{.EXEC_static}
+\alias{.EXEC_dynamic}
+\alias{.remake_EXEC}
 
 \title{Developer interface}
 
@@ -74,7 +92,7 @@
 .close(worker)
 
 ## task manager interface(optional)
-.manager(backend)
+.manager(BPPARAM)
 .manager_send(manager, value)
 .manager_recv(manager)
 .manager_send_all(manager, value)
@@ -91,6 +109,13 @@
 .bpiterate_impl(ITER, FUN, ..., REDUCE, init, reduce.in.order = FALSE,
                 BPREDO = list(), BPPARAM = bpparam())
 .bpstop_impl(x)
+
+
+## separate the static or dynamic part from an EXEC task
+.task_type(value)
+.EXEC_static(value)
+.EXEC_dynamic(value)
+.remake_EXEC(value, static_EXEC = NULL)
 }
 
 \arguments{
@@ -139,6 +164,10 @@
     For \code{.bplapply_impl()}, \code{.bpiterate_impl()}, additional
     arguments to \code{FUN()}; see \code{bplapply} and \code{bpiterate}.
 
+  }
+  
+  \item{static_EXEC}{
+    An object extracted from \code{.EXEC_static(value)}
   }
 }
 
@@ -211,6 +240,15 @@
   flushes all the cached tasks(if any) immediately. \code{.manager_cleanup()} performs
   the cleanup after the job is finished. The default methods for
   \code{.manager_flush()} and \code{.manager_cleanup()} are no-op.
+  
+  In some cases it might be worthy to cache some objects in a task and reuse them
+  in another task. This can reduce the bandwith requirement for sending the tasks
+  out to the worker. Only the EXEC task should be cached by the worker. 
+  \code{.task_type()} returns \code{"EXEC"} when an EXEC task is given. 
+  \code{EXEC_static()} can be used to extract the objects from the task which are
+  not going to change across all tasks. \code{EXEC_dynamic()} preserve only 
+  the dynamic components in a task. Given the static and dynamic task objects,
+  the complete task can be made by \code{.remake_EXEC()}. 
 
 }
 


### PR DESCRIPTION
I guess we already found a good reason why we need to cache the task. From our [test code](https://gist.github.com/mtmorgan/8886fba08bc634e4408cb73c65ac5a47). The `SnowParam` takes more than 300 seconds without the cache, but it only takes 17 seconds with the cache.

The only concern is that by caching the user-supplied `FUN`, we assume all objects in the enclosing environment of `FUN` must be constant. Otherwise, it may lead to an incorrect result. After thinking about this for days, I decide not to add an argument to control the cache behavior as the order that the task gets finished is not assured. It is possible to get two task results reduced before we sent out a new task. Therefore, dynamically changing the function data in the reducer can cause more trouble than it is worth. In our test, we just change the data in the iterator and it already makes things very hard to debug, so I consider changing any objects in the enclosing environment that `FUN` depends on is a poor design. Therefore, we do not need to support it.
