### PR TITLE
fix a validation issue for BiocParallelParam

### DIFF
--- a/R/BiocParallelParam-class.R
+++ b/R/BiocParallelParam-class.R
@@ -88,8 +88,8 @@ setValidity("BiocParallelParam", function(object)
 
     if (is.character(workers)) {
         if (length(workers) < 1L)
-            msg <- c(msg, "length(bpworkers(BPPARAM)) must be > 0") 
-        if (tasks > 0L && tasks < workers)
+            msg <- c(msg, "length(bpworkers(BPPARAM)) must be > 0")
+        if (tasks > 0L && tasks < length(workers))
             msg <- c(msg, "number of tasks is less than number of workers")
     }
 


### PR DESCRIPTION
I cannot believe no one sees this bug in practice. Perhaps that's because we do not really return the worker names from `bpworkers` in all common `PARAM`s, but `RedisParam` does, and I see it...