### PR TITLE
Add task cache feature and enable it by default for the SnowParam

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -127,5 +127,6 @@ export(
     .manager, .manager_send, .manager_recv,
     .manager_send_all, .manager_recv_all,
     .manager_capacity,
-    .manager_flush, .manager_cleanup
+    .manager_flush, .manager_cleanup,
+    .task_const, .task_dynamic, .task_remake
 )

--- a/R/DeveloperInterface.R
+++ b/R/DeveloperInterface.R
@@ -1,9 +1,10 @@
 ##
 ## see NAMESPACE section for definitive exports
 ##
+## Manager class
+.TaskManager <- setClass("TaskManager", contains = "environment")
 
 ## server
-
 setGeneric(
     ".send_to",
     function(backend, node, value) standardGeneric(".send_to"),
@@ -51,8 +52,8 @@ setGeneric(
 ## task manager
 setGeneric(
     ".manager",
-    function(backend) standardGeneric(".manager"),
-    signature = "backend"
+    function(BPPARAM) standardGeneric(".manager"),
+    signature = "BPPARAM"
 )
 
 setGeneric(
@@ -171,14 +172,15 @@ setMethod(
 ## default task manager implementation
 setMethod(
     ".manager", "ANY",
-    function(backend)
+    function(BPPARAM)
 {
-    manager <- new.env(parent = emptyenv())
-    manager$backend <- backend
-    availability <- rep(list(TRUE), length(manager$backend))
+    manager <- .TaskManager()
+    manager$BPPARAM <- BPPARAM
+    manager$backend <- bpbackend(BPPARAM)
+    manager$capacity <- length(manager$backend)
+    availability <- rep(list(TRUE), manager$capacity)
     names(availability) <- as.character(seq_along(manager$backend))
     manager$availability <- as.environment(availability)
-    manager$capacity <- length(manager$backend)
     manager
 })
 

--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -368,3 +368,67 @@ setAs("spawnedMPIcluster", "SnowParam",
     .SnowParam(.clusterargs=.clusterargs, cluster=from, .controlled=FALSE,
                workers=length(from))
 })
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### task dispatching interface
+###
+.SOCKmanager <- setClass("SOCKmanager", contains = "TaskManager")
+
+setMethod(
+    ".manager", "SnowParam",
+    function(BPPARAM)
+{
+    manager <- callNextMethod()
+    manager$initialized <- rep(FALSE, manager$capacity)
+    manager <- as(manager, "SOCKmanager")
+    manager
+})
+
+setMethod(
+  ".manager_send", "SOCKmanager",
+  function(manager, value)
+{
+    availability <- manager$availability
+    stopifnot(length(availability) >=0)
+    ## send the job to the next available worker
+    worker <- names(availability)[1]
+    id <- as.integer(worker)
+    ## Do the cache only when the snow worker is
+    ## created by our package.
+    if (.controlled(manager$BPPARAM)) {
+        if (manager$initialized[id])
+            value <- .task_dynamic(value)
+        else
+            manager$initialized[id] <- TRUE
+    }
+    .send_to(manager$backend, as.integer(worker), value)
+    rm(list = worker, envir = availability)
+    manager
+})
+
+setMethod(
+    ".manager_cleanup", "SOCKmanager",
+    function(manager)
+{
+    manager <- callNextMethod()
+    manager$initialized <- rep(FALSE, manager$capacity)
+    if (.controlled(manager$BPPARAM)) {
+        value <- .EXEC(tag = NULL, .clean_task_static, args = NULL)
+        .send_all(manager$backend, value)
+        msg <- .recv_all(manager$backend)
+    }
+    manager
+})
+
+## The worker class of SnowParam
+setOldClass(c("SOCK0node", "SOCKnode"))
+setMethod(".recv", "SOCKnode",
+    function(worker)
+{
+    msg <- callNextMethod()
+    if (inherits(msg, "error"))
+      return(msg)
+    ## read/write the static value(if any)
+    msg <- .load_task_static(msg)
+    msg
+})

--- a/R/SnowParam-utils.R
+++ b/R/SnowParam-utils.R
@@ -106,3 +106,27 @@ bprunMPIworker <- function() {
         .log_internal()
     } else .log_internal()
 }
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### EXEC command cache
+###
+
+## read/write the static value
+.load_task_static <-
+    function(value)
+{
+    static_data <- .task_const(value)
+    if (is.null(static_data)) {
+        static_data <- options("BIOCPARALLEL_SNOW_STATIC")[[1]]
+        .task_remake(value, static_data)
+    } else {
+        options(BIOCPARALLEL_SNOW_STATIC = static_data)
+        value
+    }
+}
+
+.clean_task_static <-
+    function()
+{
+    options(BIOCPARALLEL_SNOW_STATIC = NULL)
+}

--- a/R/TransientMulticoreParam-class.R
+++ b/R/TransientMulticoreParam-class.R
@@ -118,3 +118,9 @@ setMethod(
 {
     stop("'.close,TransientMulticoreParam-method' not implemented")
 })
+
+setMethod(".manager", "TransientMulticoreParam",
+          function(BPPARAM)
+{
+    selectMethod(.manager, "ANY")(BPPARAM)
+})

--- a/R/bploop.R
+++ b/R/bploop.R
@@ -198,8 +198,7 @@
 .bploop_impl <-
     function(ITER, FUN, ARGS, BPPARAM, BPREDO, OPTIONS, reducer, progress.length)
 {
-    cl <- bpbackend(BPPARAM)
-    manager <- .manager(cl)
+    manager <- .manager(BPPARAM)
     on.exit(.manager_cleanup(manager), add = TRUE)
 
     ## worker options
@@ -230,6 +229,7 @@
             X=X , FUN=FUN , ARGS = ARGS,
             OPTIONS = OPTIONS, BPRNGSEED = seed
         )
+    static.args <- c("FUN", "ARGS", "OPTIONS")
 
     total <- 0L
     running <- 0L
@@ -250,8 +250,12 @@
                     warning("first invocation of 'ITER()' returned NULL")
                 break
             }
-            value_ <- .EXEC(total + 1L, .workerLapply, ARGFUN(value, seed))
-            .manager_send(manager, value_)
+            args <- ARGFUN(value, seed)
+            task <- .EXEC(total + 1L, .workerLapply,
+                          args = args,
+                          static.fun = TRUE,
+                          static.args = static.args)
+            .manager_send(manager, task)
             seed <- .rng_iterate_substream(seed, length(value))
             total <- total + 1L
             running <- running + 1L

--- a/R/bpstart-methods.R
+++ b/R/bpstart-methods.R
@@ -68,8 +68,7 @@ setMethod("bpstart", "missing",
 .bpstart_set_logging <-
     function(x)
 {
-    cluster <- bpbackend(x)
-    manager <- .manager(cluster)
+    manager <- .manager(x)
     on.exit({.manager_cleanup(manager)})
 
     value <- .EXEC(NULL, .log_load, list(bplog(x), bpthreshold(x), TRUE))

--- a/R/bpstop-methods.R
+++ b/R/bpstop-methods.R
@@ -14,10 +14,8 @@ setMethod("bpstop", "missing",
 .bpstop_nodes <-
     function(x)
 {
-    cluster <- bpbackend(x)
-    for (i in seq_along(cluster))
-        .send_to(cluster, i, .DONE())
-
+    manager <- .manager(x)
+    .manager_send_all(manager, .DONE())
     TRUE
 }
 

--- a/R/bpvec-methods.R
+++ b/R/bpvec-methods.R
@@ -29,16 +29,8 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
     bptasks(BPPARAM) <- 0L
     on.exit(bptasks(BPPARAM) <- otasks)
 
-    idx <- .redo_index(si, BPREDO)
-
-    ## FIXME: 'X' sent to all workers, but ith worker only needs X[i]
     FUN1 <- function(i, ...) FUN(X[i], ...)
     res <- bptry(bplapply(si, FUN1, ..., BPREDO=BPREDO, BPPARAM=BPPARAM))
-
-    if (length(BPREDO) && length(idx)) {
-        BPREDO[idx] <- res
-        res <- BPREDO
-    }
 
     if (is(res, "error") || !all(bpok(res)))
         stop(.error_bplist(res))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -189,3 +189,22 @@
     )
     stop(msg, call. = FALSE)
 }
+
+## This is only used for reducing the size of
+## the function in serialization
+funcFactory <-
+    function(funcName)
+{
+    template <-
+        "
+        FUN_ <- function(...) %funcName%(...)
+        environment(FUN_) <- getNamespace('base')
+        FUN_
+        "
+    txt <- gsub("%funcName%", funcName, template ,fixed = TRUE)
+    eval(
+        parse(
+            text=txt
+        )
+    )
+}

--- a/inst/unitTests/test_errorhandling.R
+++ b/inst/unitTests/test_errorhandling.R
@@ -175,7 +175,7 @@ test_BPREDO <- function()
 test_bpvec_BPREDO <- function()
 {
     if (.Platform$OS.type != "windows") {
-        f = function(i) if (2 %in% i) stop() else sqrt(i)
+        f = function(i) if (6 %in% i) stop() else sqrt(i)
         x = 1:10
 
         doParallel::registerDoParallel(2)
@@ -190,7 +190,7 @@ test_bpvec_BPREDO <- function()
             checkTrue(is(res, "bplist_error"))
             result <- attr(res, "result")
             checkIdentical(2L, length(result))
-            checkTrue(inherits(result[[1]], "condition"))
+            checkTrue(inherits(result[[2]], "condition"))
             closeAllConnections()
             Sys.sleep(0.25)
 
@@ -200,7 +200,7 @@ test_bpvec_BPREDO <- function()
             checkTrue(is(res2, "bplist_error"))
             result <- attr(res2, "result")
             checkIdentical(2L, length(result))
-            checkTrue(is(result[[1]], "remote_error"))
+            checkTrue(is(result[[2]], "remote_error"))
             closeAllConnections()
             Sys.sleep(0.25)
 

--- a/man/DeveloperInterface.Rd
+++ b/man/DeveloperInterface.Rd
@@ -17,32 +17,49 @@
 \alias{.send,ANY-method}
 \alias{.recv}
 \alias{.recv,ANY-method}
+\alias{.recv,SOCKnode-method}
 \alias{.close}
 \alias{.close,ANY-method}
 
 
 \alias{.manager}
 \alias{.manager,ANY-method}
+\alias{.manager,SnowParam-method}
+\alias{.manager,TransientMulticoreParam-method}
 \alias{.manager_send}
 \alias{.manager_send,ANY-method}
+\alias{.manager_send,TaskManager-method}
+\alias{.manager_send,SOCKmanager-method}
 \alias{.manager_recv}
 \alias{.manager_recv,ANY-method}
+\alias{.manager_recv,TaskManager-method}
 \alias{.manager_send_all}
 \alias{.manager_send_all,ANY-method}
+\alias{.manager_send_all,TaskManager-method}
 \alias{.manager_recv_all}
 \alias{.manager_recv_all,ANY-method}
+\alias{.manager_recv_all,TaskManager-method}
 \alias{.manager_flush}
 \alias{.manager_flush,ANY-method}
+\alias{.manager_flush,TaskManager-method}
 \alias{.manager_cleanup}
 \alias{.manager_cleanup,ANY-method}
+\alias{.manager_cleanup,TaskManager-method}
+\alias{.manager_cleanup,SOCKmanager-method}
 \alias{.manager_capacity}
 \alias{.manager_capacity,ANY-method}
+\alias{.manager_capacity,TaskManager-method}
 
 \alias{.bpstart_impl}
 \alias{.bpstop_impl}
 \alias{.bpworker_impl}
 \alias{.bplapply_impl}
 \alias{.bpiterate_impl}
+
+
+\alias{.task_const}
+\alias{.task_dynamic}
+\alias{.task_remake}
 
 \title{Developer interface}
 
@@ -74,7 +91,7 @@
 .close(worker)
 
 ## task manager interface(optional)
-.manager(backend)
+.manager(BPPARAM)
 .manager_send(manager, value)
 .manager_recv(manager)
 .manager_send_all(manager, value)
@@ -91,6 +108,12 @@
 .bpiterate_impl(ITER, FUN, ..., REDUCE, init, reduce.in.order = FALSE,
                 BPREDO = list(), BPPARAM = bpparam())
 .bpstop_impl(x)
+
+
+## extract the static or dynamic part from a task
+.task_const(value)
+.task_dynamic(value)
+.task_remake(value, static_data = NULL)
 }
 
 \arguments{
@@ -139,6 +162,10 @@
     For \code{.bplapply_impl()}, \code{.bpiterate_impl()}, additional
     arguments to \code{FUN()}; see \code{bplapply} and \code{bpiterate}.
 
+  }
+
+  \item{static_data}{
+    An object extracted from \code{.task_const(value)}
   }
 }
 
@@ -211,6 +238,18 @@
   flushes all the cached tasks(if any) immediately. \code{.manager_cleanup()} performs
   the cleanup after the job is finished. The default methods for
   \code{.manager_flush()} and \code{.manager_cleanup()} are no-op.
+
+  In some cases it might be worthy to cache some objects in a task and reuse them
+  in another task. This can reduce the bandwith requirement for sending the tasks
+  out to the worker.
+  \code{.task_const()} can be used to extract the objects from the task which are
+  not going to change across all tasks. \code{.task_dynamic()} preserve only
+  the dynamic components in a task. Given the static and dynamic task objects,
+  the complete task can be recovered by \code{.task_remake()}. When there is no
+  static data can be extracted(e.g. a task with no static component or a task which
+  has been extracted by \code{.task_dynamic()}), \code{.task_const()} simply returns
+  a \code{NULL} value. Calling \code{.task_remake()} is no-op if the task haven't
+  been extracted by \code{.task_dynamic()} or the static data is \code{NULL}.
 
 }
 


### PR DESCRIPTION
This pull requests contains three new developer APIs: `.task_static`, `.task_dynamic`, and `.remake_task`. The use of these three functions is optional. All existing `Param`s work with this new version, they just cannot gain any benefit from the task cache feature.