### PR TITLE
Do not export the global environment for the SerialParam

### DIFF
--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -51,7 +51,8 @@ SerialParam <-
         logdir=logdir,
         resultdir = resultdir,
         jobname = jobname,
-        force.GC = force.GC
+        force.GC = force.GC,
+        exportglobals = FALSE
     )
     x <- do.call(.SerialParam, prototype)
     validObject(x)


### PR DESCRIPTION
It looks redundant to export the global environment for the `SerialParam`, so I disable it by default.