### PR TITLE
allow SnowParam to work with devtools

### DIFF
--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -249,10 +249,16 @@ setMethod("bpstart", "SnowParam",
         cargs$spec <- if (is.numeric(cargs$spec)) {
             nnodes
         } else cargs$spec[seq_len(nnodes)]
-        if (is.null(cargs$snowlib))
-            cargs$snowlib <- find.package("BiocParallel")
+
+        libPath <- find.package("BiocParallel")
+        if (dir.exists(file.path(libPath, "inst")))
+            libPath <- file.path(libPath, "inst")
+
+        if (is.null(cargs$snowlib)) {
+            cargs$snowlib <- libPath
+        }
         if (!is.null(cargs$useRscript) && !cargs$useRscript)
-            cargs$scriptdir <- find.package("BiocParallel")
+            cargs$scriptdir <- libPath
 
         if (x$.clusterargs$type == "SOCK") {
             cargs$master <- .hostname(x)


### PR DESCRIPTION
The `SnowParam` is not quite happy with `devtools::load_all()`, this pull request fixes the issue.

```
> devtools::load_all(".")
Loading BiocParallel
> p <- SnowParam(2)
> bpstart(p)
```