### PR TITLE
[patch 1] Add 'bpoptions'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Collate: AllGenerics.R DeveloperInterface.R prototype.R
     TransientMulticoreParam-class.R register.R
     SerialParam-class.R DoparParam-class.R SnowParam-utils.R
     BatchJobsParam-class.R BatchtoolsParam-class.R
-    progress.R ipcmutex.R utilities.R rng.R bpinit.R reducer.R worker.R
+    progress.R ipcmutex.R utilities.R rng.R bpinit.R reducer.R worker.R 
+    bpoptions.R
 LinkingTo: BH
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -54,7 +54,9 @@ export(
 
     ## ipcmutex
     ipcid, ipcremove, ipclock, ipctrylock, ipcunlock, ipclocked,
-    ipcyield, ipcvalue, ipcreset
+    ipcyield, ipcvalue, ipcreset,
+
+    bpoptions, .registerOption
 )
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -1,26 +1,28 @@
 setGeneric("bplapply", signature=c("X", "BPPARAM"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
     standardGeneric("bplapply"))
 
 setGeneric("bpmapply", signature=c("FUN", "BPPARAM"),
     function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, USE.NAMES=TRUE,
-             BPREDO=list(), BPPARAM=bpparam())
+             BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
     standardGeneric("bpmapply"))
 
 setGeneric("bpiterate", signature=c("ITER", "FUN", "BPPARAM"),
-    function(ITER, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(ITER, FUN, ..., BPREDO=list(), BPPARAM=bpparam(),
+             BPOPTIONS = bpoptions())
     standardGeneric("bpiterate"))
 
 setGeneric("bpvec", signature=c("X", "BPPARAM"),
-    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
     standardGeneric("bpvec"))
 
 setGeneric("bpvectorize",
-    function(FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(FUN, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
     standardGeneric("bpvectorize"))
 
 setGeneric("bpaggregate", signature=c("x", "BPPARAM"),
-    function(x, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(x, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
     standardGeneric("bpaggregate"))
 
 ##

--- a/R/BatchJobsParam-class.R
+++ b/R/BatchJobsParam-class.R
@@ -106,7 +106,8 @@ setMethod("bpbackend", "BatchJobsParam", function(x) BatchJobs::getConfig())
 ###
 
 setMethod("bplapply", c("ANY", "BatchJobsParam"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
     BPREDO <- bpresult(BPREDO)
@@ -115,7 +116,7 @@ setMethod("bplapply", c("ANY", "BatchJobsParam"),
         return(.rename(list(), X))
 
     if (!bpschedule(BPPARAM))
-        return(bplapply(X, FUN, ..., BPPARAM=SerialParam()))
+        return(bplapply(X, FUN, ..., BPPARAM=SerialParam(), BPOPTIONS = BPOPTIONS))
 
     idx <- .redo_index(X, BPREDO)
     if (length(idx))
@@ -196,7 +197,8 @@ setMethod("bplapply", c("ANY", "BatchJobsParam"),
 })
 
 setMethod("bpiterate", c("ANY", "ANY", "BatchJobsParam"),
-    function(ITER, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
+    function(ITER, FUN, ..., BPREDO = list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     stop("bpiterate not supported for BatchJobsParam")
 })

--- a/R/BatchtoolsParam-class.R
+++ b/R/BatchtoolsParam-class.R
@@ -346,7 +346,8 @@ setMethod("bpstop", "BatchtoolsParam",
 ###
 
 setMethod("bplapply", c("ANY", "BatchtoolsParam"),
-          function(X, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
+          function(X, FUN, ..., BPREDO = list(),
+                   BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
 
@@ -452,7 +453,7 @@ setMethod("bplapply", c("ANY", "BatchtoolsParam"),
 
 setMethod("bpiterate", c("ANY", "ANY", "BatchtoolsParam"),
     function(ITER, FUN, ..., REDUCE, init, reduce.in.order=FALSE,
-             BPREDO = list(), BPPARAM=bpparam())
+             BPREDO = list(), BPPARAM=bpparam(), BPOPTIONS=bpoptions())
 {
     ITER <- match.fun(ITER)
     FUN <- match.fun(FUN)
@@ -468,7 +469,7 @@ setMethod("bpiterate", c("ANY", "ANY", "BatchtoolsParam"),
         param <- as(BPPARAM, "SerialParam")
         return(
             bpiterate(ITER, FUN, ..., REDUCE=REDUCE, init=init,
-                      BPREDO = BPREDO, BPPARAM=param)
+                      BPREDO = BPREDO, BPPARAM=param, BPOPTIONS=BPOPTIONS)
         )
     }
 

--- a/R/DoparParam-class.R
+++ b/R/DoparParam-class.R
@@ -62,7 +62,7 @@ setMethod("bpisup", "DoparParam",
 ###
 
 setMethod("bplapply", c("ANY", "DoparParam"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     if (!length(X))
         return(.rename(list(), X))
@@ -119,7 +119,8 @@ setMethod("bplapply", c("ANY", "DoparParam"),
 })
 
 setMethod("bpiterate", c("ANY", "ANY", "DoparParam"),
-    function(ITER, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
+    function(ITER, FUN, ..., BPREDO = list(),
+             BPPARAM=bpparam(), BPOPTIONS=bpoptions())
 {
     stop("'bpiterate' not supported for DoparParam")
 })

--- a/R/bpaggregate-methods.R
+++ b/R/bpaggregate-methods.R
@@ -1,5 +1,5 @@
 ### =========================================================================
-### bpaggregate methods 
+### bpaggregate methods
 ### -------------------------------------------------------------------------
 
 ## All params use bpaggregate,data.frame,BiocParallelParam.
@@ -8,24 +8,24 @@
 
 
 setMethod("bpaggregate", c("ANY", "missing"),
-    function(x, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(x, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
-    bpaggregate(x, ..., BPREDO=BPREDO, BPPARAM=BPPARAM)
+    bpaggregate(x, ..., BPREDO=BPREDO, BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 setMethod("bpaggregate", c("matrix", "BiocParallelParam"),
-    function(x, by, FUN, ..., simplify=TRUE, 
-             BPREDO=list(), BPPARAM=bpparam())
+    function(x, by, FUN, ..., simplify=TRUE,
+             BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     if (!is.data.frame(x))
         x <- as.data.frame(x)
-    bpaggregate(x, by, FUN, ..., simplify=simplify, 
-                BPREDO=BPREDO, BPPARAM=BPPARAM)
+    bpaggregate(x, by, FUN, ..., simplify=simplify,
+                BPREDO=BPREDO, BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 setMethod("bpaggregate", c("data.frame", "BiocParallelParam"),
-    function(x, by, FUN, ..., simplify=TRUE, 
-             BPREDO=list(),  BPPARAM=bpparam())
+    function(x, by, FUN, ..., simplify=TRUE,
+             BPREDO=list(),  BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
     if (!is.data.frame(x))
@@ -42,7 +42,7 @@ setMethod("bpaggregate", c("data.frame", "BiocParallelParam"),
     grp <- rep(seq_along(ind), lengths(ind))
     grp <- grp[match(seq_len(nrow(x)), unlist(ind))]
     res <- bplapply(ind, wrapper, .x=x, .AGGRFUN=FUN, .simplify=simplify,
-                    BPREDO=BPREDO, BPPARAM=BPPARAM)
+                    BPREDO=BPREDO, BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
     res <- do.call(rbind, lapply(res, rbind))
 
     if (is.null(names(by)) && length(by)) {
@@ -62,21 +62,22 @@ setMethod("bpaggregate", c("data.frame", "BiocParallelParam"),
 })
 
 setMethod("bpaggregate", c("formula", "BiocParallelParam"),
-    function (x, data, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function (x, data, FUN, ..., BPREDO=list(),
+              BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
-    if (length(x) != 3L) 
+    if (length(x) != 3L)
         stop("Formula 'x' must have both left and right hand sides")
 
     m <- match.call(expand.dots=FALSE)
-    if (is.matrix(eval(m$data, parent.frame()))) 
+    if (is.matrix(eval(m$data, parent.frame())))
         m$data <- as.data.frame(data)
-    m$... <- m$FUN <- m$BPPARAM <- m$BPREDO <- NULL
+    m$... <- m$FUN <- m$BPPARAM <- m$BPREDO <- m$BPOPTIONS <- NULL
     m[[1L]] <- quote(stats::model.frame)
     names(m)[[2]] <- "formula"
 
     if (x[[2L]] == ".") {
         rhs <- as.list(attr(terms(x[-2L]), "variables")[-1])
-        lhs <- as.call(c(quote(cbind), 
+        lhs <- as.call(c(quote(cbind),
             setdiff(lapply(names(data), as.name), rhs)))
         x[[2L]] <- lhs
         m[[2L]] <- x
@@ -85,9 +86,9 @@ setMethod("bpaggregate", c("formula", "BiocParallelParam"),
 
     if (is.matrix(mf[[1L]])) {
         lhs <- as.data.frame(mf[[1L]])
-        bpaggregate(lhs, mf[-1L], FUN=FUN, ..., 
-                    BPREDO=BPREDO, BPPARAM=BPPARAM)
+        bpaggregate(lhs, mf[-1L], FUN=FUN, ...,
+                    BPREDO=BPREDO, BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
     }
-    else bpaggregate(mf[1L], mf[-1L], FUN=FUN, ..., 
-                     BPREDO=BPREDO, BPPARAM=BPPARAM)
+    else bpaggregate(mf[1L], mf[-1L], FUN=FUN, ...,
+                     BPREDO=BPREDO, BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })

--- a/R/bpinit.R
+++ b/R/bpinit.R
@@ -1,6 +1,11 @@
 .bpinit <-
-    function(manager, BPPARAM, ...)
+    function(manager, BPPARAM, BPOPTIONS, ...)
 {
+    ## temporarily change the paramters in BPPARAM
+    oldOptions <- .bpparamOptions(BPPARAM, names(BPOPTIONS))
+    on.exit(.bpparamOptions(BPPARAM) <- oldOptions)
+    .bpparamOptions(BPPARAM) <- BPOPTIONS
+
     ## Conditions for starting a cluster, or falling back to (and
     ## starting) a SerialParam
     nworkers <- bpnworkers(BPPARAM) # cache in case this requires a netowrk call

--- a/R/bpiterate-methods.R
+++ b/R/bpiterate-methods.R
@@ -5,17 +5,19 @@
 ## All params have dedicated bpiterate() methods.
 
 setMethod("bpiterate", c("ANY", "ANY", "missing"),
-    function(ITER, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(ITER, FUN, ..., BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS=bpoptions())
 {
     ITER <- match.fun(ITER)
     FUN <- match.fun(FUN)
-    bpiterate(ITER, FUN, ..., BPREDO = BPREDO, BPPARAM=BPPARAM)
+    bpiterate(ITER, FUN, ..., BPREDO = BPREDO,
+              BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 ## TODO: support BPREDO
 .bpiterate_impl <-
     function(ITER, FUN, ..., REDUCE, init, reduce.in.order = FALSE,
-              BPREDO = list(), BPPARAM = bpparam())
+              BPREDO = list(), BPPARAM = bpparam(), BPOPTIONS=bpoptions())
 {
     ## Required API
     ##
@@ -39,6 +41,7 @@ setMethod("bpiterate", c("ANY", "ANY", "missing"),
         FUN = FUN,
         ARGS = ARGS,
         BPPARAM = BPPARAM,
+        BPOPTIONS = BPOPTIONS,
         BPREDO = BPREDO,
         init = init,
         REDUCE = REDUCE,

--- a/R/bplapply-methods.R
+++ b/R/bplapply-methods.R
@@ -5,14 +5,17 @@
 ## All params have dedicated bplapply methods.
 
 setMethod("bplapply", c("ANY", "missing"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
-    bplapply(X, FUN, ..., BPREDO=BPREDO, BPPARAM=BPPARAM)
+    bplapply(X, FUN, ..., BPREDO=BPREDO,
+             BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 setMethod("bplapply", c("ANY", "list"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
 
@@ -27,11 +30,13 @@ setMethod("bplapply", c("ANY", "list"),
           else
             function(...) FUN(..., BPPARAM=param)
         } else FUN
-    bplapply(X, myFUN, ..., BPREDO=BPREDO, BPPARAM=BPPARAM[[1]])
+    bplapply(X, myFUN, ..., BPREDO=BPREDO,
+             BPPARAM=BPPARAM[[1]], BPOPTIONS = BPOPTIONS)
 })
 
 .bplapply_impl <-
-    function(X, FUN, ..., BPREDO = list(), BPPARAM = bpparam())
+    function(X, FUN, ..., BPREDO = list(),
+             BPPARAM = bpparam(), BPOPTIONS = bpoptions())
 {
     ## abstract 'common' implementation using accessors only
     ##
@@ -55,6 +60,7 @@ setMethod("bplapply", c("ANY", "list"),
         FUN = FUN,
         ARGS = ARGS,
         BPPARAM = BPPARAM,
+        BPOPTIONS = BPOPTIONS,
         BPREDO = BPREDO
     )
 }

--- a/R/bploop.R
+++ b/R/bploop.R
@@ -308,7 +308,8 @@ bploop <-
 ## X: the loop value after division
 ## ARGS: The function arguments for `FUN`
 bploop.lapply <-
-    function(manager, X, FUN, ARGS, BPPARAM, BPREDO = list(), ...)
+    function(manager, X, FUN, ARGS, BPPARAM,
+             BPOPTIONS = bpoptions(), BPREDO = list(), ...)
 {
     ## which need to be redone?
     redo_index <- .redo_index(X, BPREDO)
@@ -346,7 +347,8 @@ bploop.lapply <-
 ## - results not pre-allocated; list grows each iteration if no REDUCE
 bploop.iterate <-
     function(
-        manager, ITER, FUN, ARGS, BPPARAM, REDUCE, BPREDO,
+        manager, ITER, FUN, ARGS, BPPARAM,
+        BPOPTIONS = bpoptions(), REDUCE, BPREDO,
         init, reduce.in.order, ...
     )
 {

--- a/R/bpmapply-methods.R
+++ b/R/bpmapply-methods.R
@@ -1,12 +1,13 @@
 ### =========================================================================
-### bpmapply methods 
+### bpmapply methods
 ### -------------------------------------------------------------------------
 
 ## bpmapply() dispatches to bplapply() where errors and logging are handled.
 
 setMethod("bpmapply", c("ANY", "BiocParallelParam"),
-    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, 
-             USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam())
+    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE,
+             USE.NAMES=TRUE, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     ## re-package for lapply
     ddd <- .getDotsForMapply(...)
@@ -19,23 +20,27 @@ setMethod("bpmapply", c("ANY", "BiocParallelParam"),
         .mapply(.FUN, dots, .MoreArgs)[[1L]]
     }
 
-    res <- bplapply(X=seq_along(ddd[[1L]]), wrap, .FUN=FUN, .ddd=ddd, 
-                    .MoreArgs=MoreArgs, BPREDO=BPREDO, BPPARAM=BPPARAM)
+    res <- bplapply(X=seq_along(ddd[[1L]]), wrap, .FUN=FUN, .ddd=ddd,
+                    .MoreArgs=MoreArgs, BPREDO=BPREDO,
+                    BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
     .simplify(.mrename(res, ddd, USE.NAMES), SIMPLIFY)
 })
 
 setMethod("bpmapply", c("ANY", "missing"),
-    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, 
-             USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam())
+    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE,
+             USE.NAMES=TRUE, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
     bpmapply(FUN, ..., MoreArgs=MoreArgs, SIMPLIFY=SIMPLIFY,
-             USE.NAMES=USE.NAMES, BPREDO=BPREDO, BPPARAM=BPPARAM)
+             USE.NAMES=USE.NAMES, BPREDO=BPREDO,
+             BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 setMethod("bpmapply", c("ANY", "list"),
-    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, 
-             USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam())
+    function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE,
+             USE.NAMES=TRUE, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
 
@@ -44,7 +49,7 @@ setMethod("bpmapply", c("ANY", "list"),
     if (length(BPPARAM) == 0L)
         stop("'length(BPPARAM)' must be > 0")
 
-    myFUN <- 
+    myFUN <-
         if (length(BPPARAM) > 1L) {
           if (length(param <- BPPARAM[-1]) == 1L)
             function(...) FUN(..., BPPARAM=param[[1]])
@@ -52,5 +57,6 @@ setMethod("bpmapply", c("ANY", "list"),
             function(...) FUN(..., BPPARAM=param)
         } else FUN
     bpmapply(myFUN, ..., MoreArgs=MoreArgs, SIMPLIFY=SIMPLIFY,
-             USE.NAMES=USE.NAMES, BPREDO=BPREDO, BPPARAM=BPPARAM[[1L]])
+             USE.NAMES=USE.NAMES, BPREDO=BPREDO,
+             BPPARAM=BPPARAM[[1L]], BPOPTIONS = BPOPTIONS)
 })

--- a/R/bpoptions.R
+++ b/R/bpoptions.R
@@ -1,0 +1,120 @@
+.optionRegistry <- setRefClass(".BiocParallelOptionsRegistry",
+    fields=list(
+        options = "list"),
+    methods=list(
+        register = function(optionName, genericName) {
+            if (!is.null(.self$options[[optionName]]))
+                message("Replacing the function `",
+                        optionName,
+                        "` from the option registry")
+            .self$options[[optionName]] <- genericName
+            invisible(registered())
+        },
+        registered = function() {
+            .self$options
+        })
+)$new()  # Singleton
+
+## Functions to register the S4generic for BPPARAM
+.registeredOptions <-
+    function()
+{
+    .optionRegistry$registered()
+}
+
+.registerOption <-
+    function(optionName, genericName)
+{
+    getter <- getGeneric(genericName)
+    setter <- getGeneric(paste0(genericName, "<-"))
+    if (is.null(getter))
+        stop("The S4 function '", genericName, "' is not found")
+    if (is.null(setter))
+        stop("The S4 replacement function '", genericName, "' is not found")
+    .optionRegistry$register(optionName, genericName)
+}
+
+.registerOption("workers", "bpworkers")
+.registerOption("tasks", "bptasks")
+.registerOption("jobname", "bpjobname")
+.registerOption("log", "bplog")
+.registerOption("logdir", "bplogdir")
+.registerOption("threshold", "bpthreshold")
+.registerOption("resultdir", "bpresultdir")
+.registerOption("stop.on.error", "bpstopOnError")
+.registerOption("timeout", "bptimeout")
+.registerOption("exportglobals", "bpexportglobals")
+.registerOption("progressbar", "bpprogressbar")
+.registerOption("RNGseed", "bpRNGseed")
+.registerOption("force.GC", "bpforceGC")
+
+## functions for changing the paramters in BPPARAM
+.bpparamOptions <-
+    function(BPPARAM, optionNames)
+{
+    registeredOptions <- .registeredOptions()
+    ## find the common parameters both BPPARAM and BPOPTIONS
+    paramOptions <- intersect(names(registeredOptions), optionNames)
+    getterNames <- unlist(registeredOptions[paramOptions])
+    setNames(lapply(
+        getterNames,
+        do.call,
+        args = list(BPPARAM)
+    ), paramOptions)
+}
+
+## value: BPOPTIONS
+`.bpparamOptions<-` <-
+    function(BPPARAM, value)
+{
+    BPOPTIONS <- value
+    registeredOptions <- .registeredOptions()
+    optionNames <- names(BPOPTIONS)
+    paramOptions <- intersect(names(registeredOptions), optionNames)
+    setterNames <- paste0(unlist(registeredOptions[paramOptions]), "<-")
+    for (i in seq_along(paramOptions)) {
+        paramOption <- paramOptions[i]
+        setterName <- setterNames[i]
+        do.call(
+            setterName,
+            args = list(BPPARAM, BPOPTIONS[[paramOption]])
+        )
+    }
+    BPPARAM
+}
+
+## Check any possible issues in bpoptions
+.validateBpoptions <-
+    function(BPOPTIONS)
+{
+    bpoptionsArgs <- names(formals(bpoptions))
+    registeredOptions <- names(.registeredOptions())
+    allOptions <- c(bpoptionsArgs, registeredOptions)
+    idx <- which(!names(BPOPTIONS) %in%allOptions)
+    if (length(idx))
+        message("Unregistered options found in bpoptions:\n",
+                  paste0(names(BPOPTIONS)[idx], collapse = ", "))
+}
+
+## The function simply return a list of its arguments
+bpoptions <-
+    function(
+        workers, tasks, jobname,
+        log, logdir, threshold,
+        resultdir, stop.on.error,
+        timeout, exportglobals, progressbar,
+        RNGseed, force.GC, ...)
+{
+        dotsArgs <- list(...)
+        passed <- names(as.list(match.call())[-1])
+        passed <- setdiff(passed, names(dotsArgs))
+        if (length(passed))
+            passedArgs <- setNames(mget(passed), passed)
+        else
+            passedArgs <- NULL
+        opts <- c(passedArgs, dotsArgs)
+        .validateBpoptions(opts)
+        opts
+}
+
+

--- a/R/bpvec-methods.R
+++ b/R/bpvec-methods.R
@@ -6,7 +6,8 @@
 ## handled.
 
 setMethod("bpvec", c("ANY", "BiocParallelParam"),
-    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     if (!length(X))
         return(.rename(list(), X))
@@ -19,7 +20,8 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
         param <- as(BPPARAM, "SerialParam")
         return(
             bpvec(
-                X, FUN, ..., AGGREGATE=AGGREGATE, BPREDO=BPREDO, BPPARAM = param
+                X, FUN, ..., AGGREGATE=AGGREGATE, BPREDO=BPREDO,
+                BPPARAM = param, BPOPTIONS = BPOPTIONS
             )
         )
     }
@@ -30,7 +32,8 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
     on.exit(bptasks(BPPARAM) <- otasks)
 
     FUN1 <- function(i, ...) FUN(X[i], ...)
-    res <- bptry(bplapply(si, FUN1, ..., BPREDO=BPREDO, BPPARAM=BPPARAM))
+    res <- bptry(bplapply(si, FUN1, ..., BPREDO=BPREDO,
+                          BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS))
 
     if (is(res, "error") || !all(bpok(res)))
         stop(.error_bplist(res))
@@ -42,15 +45,18 @@ setMethod("bpvec", c("ANY", "BiocParallelParam"),
 })
 
 setMethod("bpvec", c("ANY", "missing"),
-    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., AGGREGATE=c, BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
     AGGREGATE <- match.fun(AGGREGATE)
-    bpvec(X, FUN, ..., AGGREGATE=AGGREGATE, BPREDO=BPREDO, BPPARAM=BPPARAM)
+    bpvec(X, FUN, ..., AGGREGATE=AGGREGATE, BPREDO=BPREDO,
+          BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
 })
 
 setMethod("bpvec", c("ANY", "list"),
-    function(X, FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+    function(X, FUN, ..., BPREDO=list(),
+             BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 {
     FUN <- match.fun(FUN)
 
@@ -67,5 +73,5 @@ setMethod("bpvec", c("ANY", "list"),
             function(...) FUN(..., BPPARAM=param)
     } else FUN
 
-    bpvec(X, myFUN, ..., BPREDO=BPREDO, BPPARAM=BPPARAM[[1]])
+    bpvec(X, myFUN, ..., BPREDO=BPREDO, BPPARAM=BPPARAM[[1]], BPOPTIONS = BPOPTIONS)
 })

--- a/inst/unitTests/test_bpoptions.R
+++ b/inst/unitTests/test_bpoptions.R
@@ -1,0 +1,40 @@
+checkMsg <- function(x) {
+    res <- capture.output(x, type = "message")
+    checkTrue(length(res) > 0)
+}
+
+## Normal reduce process
+test_bpoptions_constructor <- function() {
+    opts <- bpoptions()
+    checkIdentical(opts, list())
+
+    opts <- bpoptions(tasks = 1)
+    checkIdentical(opts, list(tasks = 1))
+
+    checkMsg(opts <- bpoptions(randomArg = 1))
+    checkIdentical(opts, list(randomArg = 1))
+
+    checkMsg(opts <- bpoptions(tasks = 1, randomArg = 1))
+    checkIdentical(opts, list(tasks = 1, randomArg = 1))
+}
+
+test_bpoptions_bplapply <- function() {
+    p <- SerialParam()
+
+    ## bpoptions only changes BPPARAM temporarily
+    oldValue <- bptasks(p)
+    opts <- bpoptions(tasks = 100)
+    bplapply(1:2, function(x) x, BPPARAM = p, BPOPTIONS = opts)
+    checkIdentical(bptasks(p), oldValue)
+
+    ## check if bpoptions really works
+    opts <- bpoptions(timeout = 1)
+    checkException(
+        bplapply(1:2, function(x) Sys.sleep(2), BPPARAM = p,
+                 BPOPTIONS = opts)
+    )
+
+    ## Random argument has no effect on bplapply
+    checkMsg(opts <- bpoptions(randomArg = 100))
+    bplapply(1:2, function(x) x, BPPARAM = p, BPOPTIONS = opts)
+}

--- a/man/DeveloperInterface.Rd
+++ b/man/DeveloperInterface.Rd
@@ -61,6 +61,8 @@
 \alias{.task_dynamic}
 \alias{.task_remake}
 
+\alias{.registerOption}
+
 \title{Developer interface}
 
 \description{
@@ -104,9 +106,9 @@
 
 .bpstart_impl(x)
 .bpworker_impl(worker)
-.bplapply_impl(X, FUN, ..., BPREDO = list(), BPPARAM = bpparam())
+.bplapply_impl(X, FUN, ..., BPREDO = list(), BPPARAM = bpparam(), BPOPTIONS = bpoptions())
 .bpiterate_impl(ITER, FUN, ..., REDUCE, init, reduce.in.order = FALSE,
-                BPREDO = list(), BPPARAM = bpparam())
+                BPREDO = list(), BPPARAM = bpparam(), BPOPTIONS = bpoptions())
 .bpstop_impl(x)
 
 
@@ -114,6 +116,9 @@
 .task_const(value)
 .task_dynamic(value)
 .task_remake(value, static_data = NULL)
+
+## Register an option for BPPARAM
+.registerOption(optionName, genericName)
 }
 
 \arguments{
@@ -166,6 +171,18 @@
 
   \item{static_data}{
     An object extracted from \code{.task_const(value)}
+  }
+
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
+
+  \item{optionName}{
+    Character(1), an option name for \code{BPPARAM}. The named options will be created by \code{\link{bpoptions}}
+  }
+
+  \item{genericName}{
+    Character(1), the name of the S4 generic function. It will be used to get/set the field in \code{BPPARAM}. The generic needs to support the replacement function defined by \code{\link{setReplaceMethod}}.
   }
 }
 
@@ -254,6 +271,16 @@
   the task haven't been extracted by \code{.task_dynamic()} or the
   static data is \code{NULL}.
 
+  The function \code{.registerOption} allows the developer to register the
+  generic function that can change the fields in \code{BPPARAM}. There is no
+  need to register the fields which has already been defined in
+  \code{BiocParallel}. \code{.registerOption} should only be used to support new
+  fields. For example, if the developer define a \code{BPPARAM} which has a
+  field \code{worker.password}, the developer may also define the getter/
+  setter like \code{bpworkerPassword}. Then by calling
+  \code{.registerOption("worker.password", "bpworkerPassword")}, the user
+  can change the field in \code{BPPARAM} by passing an object of
+  \code{bpoptions(worker.password = "1234")} in any apply function.
 }
 
 \value{

--- a/man/bpaggregate.Rd
+++ b/man/bpaggregate.Rd
@@ -16,21 +16,21 @@
 
 \usage{
 
-\S4method{bpaggregate}{formula,BiocParallelParam}(x, data, FUN, ..., 
-    BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpaggregate}{formula,BiocParallelParam}(x, data, FUN, ...,
+    BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpaggregate}{data.frame,BiocParallelParam}(x, by, FUN, ..., 
-    simplify=TRUE, BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpaggregate}{data.frame,BiocParallelParam}(x, by, FUN, ...,
+    simplify=TRUE, BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpaggregate}{matrix,BiocParallelParam}(x, by, FUN, ..., 
-    simplify=TRUE, BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpaggregate}{matrix,BiocParallelParam}(x, by, FUN, ...,
+    simplify=TRUE, BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpaggregate}{ANY,missing}(x, ..., BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpaggregate}{ANY,missing}(x, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
 }
 
 \arguments{
-  
+
   \item{x}{A \code{data.frame}, \code{matrix} or a formula.
   }
   \item{by}{A list of factors by which \code{x} is split;
@@ -54,20 +54,23 @@
     \code{bpok} is used to identify errors, tasks are rerun and inserted
     into the original results.
   }
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 }
 
 \details{
 
   \code{bpaggregate} is a generic with methods for \code{data.frame}
   \code{matrix} and \code{formula} objects. \code{x} is divided
-  into subsets according to factors in \code{by}. Data chunks are 
+  into subsets according to factors in \code{by}. Data chunks are
   sent to the workers, \code{FUN} is applied and results are returned
   as a \code{data.frame}.
 
   The function is similar in spirit to \code{\link[stats]{aggregate}}
-  from the stats package but \code{\link[stats]{aggregate}} is not 
-  explicitly called. The \code{bpaggregate} \code{formula} method 
-  reformulates the call and dispatches to the \code{data.frame} method 
+  from the stats package but \code{\link[stats]{aggregate}} is not
+  explicitly called. The \code{bpaggregate} \code{formula} method
+  reformulates the call and dispatches to the \code{data.frame} method
   which in turn distributes data chunks to workers with \code{bplapply}.
 
 }
@@ -88,12 +91,12 @@ if (interactive() && require(Rsamtools) && require(GenomicAlignments)) {
 
   fl <- system.file("extdata", "ex1.bam", package="Rsamtools")
   param <- ScanBamParam(what = c("flag", "mapq"))
-  gal <- readGAlignments(fl, param=param) 
+  gal <- readGAlignments(fl, param=param)
 
   ## Report the mean map quality by range cutoff:
   cutoff <- rep(0, length(gal))
   cutoff[start(gal) > 1000 & start(gal) < 1500] <- 1
-  cutoff[start(gal) > 1500] <- 2 
+  cutoff[start(gal) > 1500] <- 2
   bpaggregate(as.data.frame(mcols(gal)$mapq), list(cutoff = cutoff), mean)
 
 }

--- a/man/bpiterate.Rd
+++ b/man/bpiterate.Rd
@@ -20,14 +20,14 @@
 }
 
 \usage{
-bpiterate(ITER, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
+bpiterate(ITER, FUN, ..., BPREDO = list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpiterate}{ANY,ANY,missing}(ITER, FUN, ..., 
-    BPREDO = list(), BPPARAM=bpparam())
+\S4method{bpiterate}{ANY,ANY,missing}(ITER, FUN, ...,
+    BPREDO = list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
 \S4method{bpiterate}{ANY,ANY,BatchtoolsParam}(
     ITER, FUN, ..., REDUCE, init, reduce.in.order=FALSE,
-    BPREDO = list(), BPPARAM=bpparam()
+    BPREDO = list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions()
 )
 }
 
@@ -72,6 +72,9 @@ bpiterate(ITER, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
   \item{\dots}{Arguments to other methods, and named arguments for
     \code{FUN}.}
 
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 }
 
 \details{

--- a/man/bplapply.Rd
+++ b/man/bplapply.Rd
@@ -20,13 +20,13 @@
 }
 
 \usage{
-bplapply(X, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
+bplapply(X, FUN, ..., BPREDO = list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 }
 
 \arguments{
 
   \item{X}{
-    Any object for which methods \code{length}, \code{[}, and 
+    Any object for which methods \code{length}, \code{[}, and
     \code{[[} are implemented.
   }
   \item{FUN}{
@@ -45,6 +45,9 @@ bplapply(X, FUN, ..., BPREDO = list(), BPPARAM=bpparam())
     more failed elements. When a list is given in \code{BPREDO},
     \code{bpok} is used to identify errors, tasks are rerun and inserted
     into the original results.
+  }
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
   }
 
 }
@@ -83,7 +86,7 @@ fun <- function(v) {
     message("working") ## 10 tasks
     sqrt(v)
 }
-bplapply(1:10, fun) 
+bplapply(1:10, fun)
 }
 
 \keyword{manip}

--- a/man/bploop.Rd
+++ b/man/bploop.Rd
@@ -22,9 +22,9 @@
 }
 
 \usage{
-\S3method{bploop}{lapply}(manager, X, FUN, ARGS, BPPARAM, BPREDO, ...)
+\S3method{bploop}{lapply}(manager, X, FUN, ARGS, BPPARAM, BPOPTIONS = bpoptions(), BPREDO, ...)
 
-\S3method{bploop}{iterate}(manager, ITER, FUN, ARGS, BPPARAM,
+\S3method{bploop}{iterate}(manager, ITER, FUN, ARGS, BPPARAM, BPOPTIONS = bpoptions(),
        REDUCE, BPREDO, init, reduce.in.order, ...)
 }
 
@@ -59,6 +59,10 @@
    or \code{bpiterate} with one or more failed elements.}
 
   \item{\ldots}{Additional arguments, ignored in all cases.}
+
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 }
 
 \details{

--- a/man/bpmapply.Rd
+++ b/man/bpmapply.Rd
@@ -19,13 +19,14 @@
 \usage{
 
 bpmapply(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, USE.NAMES=TRUE,
-    BPREDO=list(), BPPARAM=bpparam())
+    BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpmapply}{ANY,missing}(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, 
-    USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpmapply}{ANY,missing}(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE,
+    USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpmapply}{ANY,BiocParallelParam}(FUN, ..., MoreArgs=NULL, 
-    SIMPLIFY=TRUE, USE.NAMES=TRUE, BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpmapply}{ANY,BiocParallelParam}(FUN, ..., MoreArgs=NULL,
+    SIMPLIFY=TRUE, USE.NAMES=TRUE, BPREDO=list(),
+    BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
 }
 
@@ -55,11 +56,14 @@ bpmapply(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, USE.NAMES=TRUE,
     \code{bpok} is used to identify errors, tasks are rerun and inserted
     into the original results.
   }
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 
 }
 
 \details{
- 
+
   See \code{methods{bpmapply}} for additional methods, e.g.,
   \code{method?bpmapply("MulticoreParam")}.
 
@@ -68,7 +72,7 @@ bpmapply(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE, USE.NAMES=TRUE,
 \value{See \code{\link[base]{mapply}}.}
 
 \author{
- 
+
   Michel Lang . Original code as attributed in
   \code{\link{mclapply}}.
 

--- a/man/bpoptions.Rd
+++ b/man/bpoptions.Rd
@@ -1,0 +1,52 @@
+\name{bpoptions}
+
+\alias{bpoptions}
+
+\title{Additional options to parallel evaluation}
+
+\description{
+    This function is used to pass the additional options to the apply function. One use case is to use the argument \code{BPOPTIONS} in the apply function to temporarily change the parameter of \code{BPPARAM}(e.g. enabling the progressbar). It can also be used to change the behavior of the parallel evaluation(e.g. disabling fallback)
+}
+\usage{
+bpoptions(
+        workers, tasks, jobname,
+        log, logdir, threshold,
+        resultdir, stop.on.error,
+        timeout, exportglobals, progressbar,
+        RNGseed, force.GC, ...)
+}
+
+\arguments{
+  \item{workers}{A parameter for \code{BPPARAM}; see \code{\link{bpnworkers}}.}
+  \item{tasks}{A parameter for \code{BPPARAM}; see \code{\link{bptasks}}.}
+  \item{jobname}{A parameter for \code{BPPARAM}; see \code{\link{bpjobname}}.}
+  \item{log}{A parameter for \code{BPPARAM}; see \code{\link{bplog}}.}
+  \item{logdir}{A parameter for \code{BPPARAM}; see \code{\link{bplogdir}}.}
+  \item{threshold}{A parameter for \code{BPPARAM}; see \code{\link{bpthreshold}}.}
+  \item{resultdir}{A parameter for \code{BPPARAM}; see \code{\link{bpresultdir}}.}
+  \item{stop.on.error}{A parameter for \code{BPPARAM}; see \code{\link{bpstopOnError}}.}
+  \item{timeout}{A parameter for \code{BPPARAM}; see \code{\link{bptimeout}}.}
+  \item{exportglobals}{A parameter for \code{BPPARAM}; see \code{\link{bpexportglobals}}.}
+  \item{progressbar}{A parameter for \code{BPPARAM}; see \code{\link{bpprogressbar}}.}
+  \item{RNGseed}{A parameter for \code{BPPARAM}; see \code{\link{bpRNGseed}}.}
+  \item{force.GC}{A parameter for \code{BPPARAM}; see \code{\link{bpforceGC}}.}
+  \item{...}{Additional arguments which may(or may not) work for some specific type of \code{BPPARAM}.}
+
+}
+
+\value{
+  A list of options
+}
+
+\author{Jiefei Wang}
+
+\seealso{
+  \code{\link{BiocParallelParam}}, \code{\link{bplapply}}, \code{\link{bpiterate}}.
+}
+\examples{
+  p <- SerialParam()
+  bplapply(1:5, function(x) Sys.sleep(1), BPPARAM = p,
+         BPOPTIONS = bpoptions(progressbar = TRUE, tasks = 5L))
+}
+
+\keyword{manip}

--- a/man/bpvec.Rd
+++ b/man/bpvec.Rd
@@ -16,7 +16,7 @@
 }
 
 \usage{
-bpvec(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
+bpvec(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 }
 
 \arguments{
@@ -52,6 +52,9 @@ bpvec(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
     \code{bpok} is used to identify errors, tasks are rerun and inserted
     into the original results.
   }
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 
 }
 
@@ -77,7 +80,7 @@ bpvec(X, FUN, ..., AGGREGATE=c, BPREDO=list(), BPPARAM=bpparam())
 
 \value{
 
-  The result should be identical to \code{FUN(X, ...)} (assuming that 
+  The result should be identical to \code{FUN(X, ...)} (assuming that
   \code{AGGREGATE} is set appropriately).
 
   When evaluation of individual elements of \code{X} results in an
@@ -115,7 +118,7 @@ fun <- function(v) {
     message("working")
     sqrt(v)
 }
-system.time(result <- bpvec(1:10, fun)) 
+system.time(result <- bpvec(1:10, fun))
 result
 
 ## invalid FUN -- length(class(X)) is not equal to length(X)

--- a/man/bpvectorize.Rd
+++ b/man/bpvectorize.Rd
@@ -16,12 +16,12 @@
 }
 
 \usage{
-bpvectorize(FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+bpvectorize(FUN, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpvectorize}{ANY,ANY}(FUN, ..., BPREDO=list(), BPPARAM=bpparam())
+\S4method{bpvectorize}{ANY,ANY}(FUN, ..., BPREDO=list(), BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
-\S4method{bpvectorize}{ANY,missing}(FUN, ..., BPREDO=list(), 
-    BPPARAM=bpparam())
+\S4method{bpvectorize}{ANY,missing}(FUN, ..., BPREDO=list(),
+    BPPARAM=bpparam(), BPOPTIONS = bpoptions())
 
 }
 
@@ -44,6 +44,9 @@ bpvectorize(FUN, ..., BPREDO=list(), BPPARAM=bpparam())
     into the original results.
   }
 
+  \item{BPOPTIONS}{
+    Additional options to control the behavior of the parallel evaluation, see \code{\link{bpoptions}}.
+  }
 }
 
 \details{


### PR DESCRIPTION
After our discussion on Tuesday, I think it is better to set `fallback` as an attribute of `BPPARAM`, so this pull request only contains the vanilla `bpoptions`. `fallback` and `exports` will be added in the other pull requests.