### PR TITLE
fix a minor print issue in error handling function

### DIFF
--- a/R/ErrorHandling.R
+++ b/R/ErrorHandling.R
@@ -147,5 +147,5 @@ print.remote_error <- function(x, ...) {
 
 `print.bplist_error` <- function(x, ...) {
     NextMethod(x)
-    cat("results and errors available as 'attr(x, \"result\")'\n")
+    cat("results and errors available as 'bpresult(x)'\n")
 }


### PR DESCRIPTION
The original error message is 
```
results and errors available as 'attr(x, "result")'
```
I change it to 
```
results and errors available as 'bpresult(x)'
```