### PR TITLE
Reset the RNG seed stream when the RNG seed is reset

### DIFF
--- a/R/BiocParallelParam-class.R
+++ b/R/BiocParallelParam-class.R
@@ -310,6 +310,7 @@ setReplaceMethod("bpRNGseed", c("BiocParallelParam", "NULL"),
     function(x, value)
 {
     x$RNGseed <- NULL
+    .RNGstream(x) <- NULL
     validObject(x)
     x
 })
@@ -318,6 +319,7 @@ setReplaceMethod("bpRNGseed", c("BiocParallelParam", "numeric"),
     function(x, value)
 {
     x$RNGseed <- as.integer(value)
+    .RNGstream(x) <- NULL
     validObject(x)
     x
 })
@@ -325,6 +327,8 @@ setReplaceMethod("bpRNGseed", c("BiocParallelParam", "numeric"),
 .RNGstream <-
     function(x)
 {
+    if (length(x$RNGstream) == 0)
+        .RNGstream(x) <- .rng_init_stream(bpRNGseed(x))
     x$RNGstream
 }
 


### PR DESCRIPTION
After the `BPPARAM` has been started, resetting its seed would not reset its seed stream. For example
```
library(BiocParallel)
p <- SerialParam()
bpstart(p)
bpRNGseed(p) <- 123
bplapply(1, function(x)runif(1), BPPARAM = p)
# [[1]]
# [1] 0.2381117

## reset the seed, but the result is different
bpRNGseed(p) <- 123
bplapply(1, function(x)runif(1), BPPARAM = p)
# [[1]]
# [1] 0.9076141
```
This pull request fixes the issue.