### PR TITLE
allow multiple managers to share the same worker without having log c…

### DIFF
--- a/R/SnowParam-class.R
+++ b/R/SnowParam-class.R
@@ -351,16 +351,8 @@ setReplaceMethod("bpbackend", c("SnowParam", "cluster"),
 setReplaceMethod("bplog", c("SnowParam", "logical"),
     function(x, value)
 {
-    if (x$.controlled) {
-        x$log <- value
-        if (bpisup(x)) {
-            bpstop(x)
-            bpstart(x)
-        }
-        x
-    } else {
-        stop("'bplog' not available; instance from outside BiocParallel?")
-    }
+    x$log <- value
+    x
 })
 
 setReplaceMethod("bpthreshold", c("SnowParam", "character"),

--- a/R/SnowParam-utils.R
+++ b/R/SnowParam-utils.R
@@ -79,39 +79,6 @@ bprunMPIworker <- function() {
 }
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-### logs and results
-###
-
-.bpwriteLog <- function(con, d) {
-    .log_internal <- function() {
-        message(
-            "############### LOG OUTPUT ###############\n",
-            "Task: ", d$value$tag,
-            "\nNode: ", d$node,
-            "\nTimestamp: ", Sys.time(),
-            "\nSuccess: ", d$value$success,
-            "\n\nTask duration:\n",
-            paste(capture.output(d$value$time), collapse="\n"),
-            "\n\nMemory used:\n", paste(capture.output(gc()), collapse="\n"),
-            "\n\nLog messages:\n",
-            paste(trimws(d$value$log), collapse="\n"),
-            "\n\nstderr and stdout:\n",
-            if (!is.null(d$value$sout))
-                paste(noquote(d$value$sout), collapse="\n")
-        )
-    }
-    if (!is.null(con)) {
-        on.exit({
-            sink(NULL, type = "message")
-            sink(NULL, type = "output")
-        })
-        sink(con, type = "message")
-        sink(con, type = "output")
-        .log_internal()
-    } else .log_internal()
-}
-
-### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### EXEC command cache
 ###
 

--- a/R/bploop.R
+++ b/R/bploop.R
@@ -203,9 +203,11 @@
 
     ## worker options
     OPTIONS <- .workerOptions(
-        bplog(BPPARAM), bpstopOnError(BPPARAM),
-        timeout=bptimeout(BPPARAM),
-        exportglobals=bpexportglobals(BPPARAM),
+        log = bplog(BPPARAM),
+        threshold = bpthreshold(BPPARAM),
+        stop.on.error = bpstopOnError(BPPARAM),
+        timeout = bptimeout(BPPARAM),
+        exportglobals = bpexportglobals(BPPARAM),
         force.GC = bpforceGC(BPPARAM)
     )
 

--- a/R/bpstart-methods.R
+++ b/R/bpstart-methods.R
@@ -65,20 +65,6 @@ setMethod("bpstart", "missing",
     invisible(.RNGstream(x))
 }
 
-.bpstart_set_logging <-
-    function(x)
-{
-    manager <- .manager(x)
-    on.exit({.manager_cleanup(manager)})
-
-    value <- .EXEC(NULL, .log_load, list(bplog(x), bpthreshold(x), TRUE))
-    .manager_send_all(manager, value)
-    .manager_flush(manager)
-    response <- .manager_recv_all(manager)
-
-    .bpstart_error_handler(x, response, "set_logging")
-    invisible(x)
-}
 
 .bpstart_set_finalizer <-
     function(x)
@@ -102,10 +88,6 @@ setMethod("bpstart", "missing",
 
     ## initialize the random number stream
     .bpstart_set_rng_stream(x)
-
-    ## logging
-    if (bplog(x))
-        .bpstart_set_logging(x)
 
     ## clean up when x left open
     .bpstart_set_finalizer(x)

--- a/R/log.R
+++ b/R/log.R
@@ -1,16 +1,30 @@
-.log_load <- function(log, threshold, appender = FALSE)
+.log_data <- local({
+    env <- new.env(parent=emptyenv())
+    env[["buffer"]] <- character()
+    env
+})
+
+.log_load <- function(log, threshold)
 {
-    if (!log)
+    if (!log) {
+        if (isNamespaceLoaded("futile.logger")) {
+            futile.logger::flog.appender(
+                futile.logger::appender.console(),
+                'ROOT'
+                )
+        }
         return(invisible(NULL))
+    }
+
+    ## log == TRUE
     if (!isNamespaceLoaded("futile.logger"))
         tryCatch({
             loadNamespace("futile.logger")
         }, error=function(err) {
             msg <- "logging requires the 'futile.logger' package"
-            stop(conditionMessage(err), msg) 
+            stop(conditionMessage(err), msg)
         })
-    if (appender)
-        futile.logger::flog.appender(.log_buffer_append, 'ROOT')
+    futile.logger::flog.appender(.log_buffer_append, 'ROOT')
     futile.logger::flog.threshold(threshold)
     futile.logger::flog.info("loading futile.logger package")
 }
@@ -29,23 +43,51 @@
 
 ## logging buffer
 
-.log_buffer <- local({
-    env <- new.env(parent=emptyenv())
-    env[["buffer"]] <- character()
-    env
-})
-
 .log_buffer_init <- function()
 {
-    .log_buffer[["buffer"]] <- NULL
+    .log_data[["buffer"]] <- character()
 }
 
 .log_buffer_append <- function(line)
 {
-    .log_buffer[["buffer"]] <- c(.log_buffer[["buffer"]], line)
+    .log_data[["buffer"]] <- c(.log_data[["buffer"]], line)
 }
 
 .log_buffer_get <- function()
 {
-    .log_buffer[["buffer"]]
+    .log_data[["buffer"]]
+}
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### logs and results printed in the manager process
+###
+
+.bpwriteLog <- function(con, d) {
+    .log_internal <- function() {
+        message(
+            "############### LOG OUTPUT ###############\n",
+            "Task: ", d$value$tag,
+            "\nNode: ", d$node,
+            "\nTimestamp: ", Sys.time(),
+            "\nSuccess: ", d$value$success,
+            "\n\nTask duration:\n",
+            paste(capture.output(d$value$time), collapse="\n"),
+            "\n\nMemory used:\n", paste(capture.output(gc()), collapse="\n"),
+            "\n\nLog messages:\n",
+            paste(trimws(d$value$log), collapse="\n"),
+            "\n\nstderr and stdout:\n",
+            if (!is.null(d$value$sout))
+                paste(noquote(d$value$sout), collapse="\n")
+        )
+    }
+    if (!is.null(con)) {
+        on.exit({
+            sink(NULL, type = "message")
+            sink(NULL, type = "output")
+        })
+        sink(con, type = "message")
+        sink(con, type = "output")
+    }
+    .log_internal()
 }

--- a/inst/unitTests/test_logging.R
+++ b/inst/unitTests/test_logging.R
@@ -17,7 +17,7 @@ test_log <- function()
             bplapply(list(1, "2", 3), sqrt, BPPARAM=param)
         }, error=identity))
         checkTrue(is(res, "bplist_error"))
-        result <- attr(res, "result")
+        result <- bpresult(res)
         checkTrue(length(result) == 3L)
         msg <- "non-numeric argument to mathematical function"
         checkIdentical(conditionMessage(result[[2]]), msg)


### PR DESCRIPTION
This pull request allows multiple managers to share the same workers without having a log setting conflict. This is done by setting the log initialization process as a part of the task that is going to be evaluated by the worker. It also has a surprising side-effect as we are able to enable the log for the `SnowParam` which is created by the `parallel` package. For example

```
library(RedisParam)
library(parallel)
p <- as(makeCluster(1), "SnowParam")
bplog(p) <- TRUE
bplapply(1, function(x)x, BPPARAM = p)
############### LOG OUTPUT ###############
# Task: 1
# Node: 1
# Timestamp: 2022-05-18 17:02:03
# Success: TRUE
```