### PR TITLE
Improve the readability of the unit test result

### DIFF
--- a/inst/unitTests/test_BatchJobsParam.R
+++ b/inst/unitTests/test_BatchJobsParam.R
@@ -1,5 +1,7 @@
-test_BatchJobsParam <- 
-    function() 
+message("Testing BatchJobsParam")
+
+test_BatchJobsParam <-
+    function()
 {
     param <- BatchJobsParam(2, progressbar=FALSE, cleanup=TRUE)
     checkEquals(as.list(sqrt(1:3)), bplapply(1:3, sqrt, BPPARAM=param))
@@ -10,5 +12,5 @@ test_BatchJobsParam <-
         bplapply(X, sqrt, BPPARAM=param)
     }, error=identity)
     checkTrue(is(res, "bplist_error"))
-    checkTrue(is(attr(res, "result")[[2]], "remote_error"))
+    checkTrue(is(bpresult(res)[[2]], "remote_error"))
 }

--- a/inst/unitTests/test_BatchtoolsParam.R
+++ b/inst/unitTests/test_BatchtoolsParam.R
@@ -1,3 +1,5 @@
+message("Testing BatchtoolsParam")
+
 .old_options <- NULL
 
 .setUp <- function()

--- a/inst/unitTests/test_BiocParallelParam.R
+++ b/inst/unitTests/test_BiocParallelParam.R
@@ -1,3 +1,5 @@
+message("Testing BiocParallelParam")
+
 test_BiocParallelParam <-
     function()
 {

--- a/inst/unitTests/test_DoparParam.R
+++ b/inst/unitTests/test_DoparParam.R
@@ -1,3 +1,5 @@
+message("Testing DoparParam")
+
 test_DoparParam_orchestration_error <- function() {
     test <-
         requireNamespace("foreach", quietly = TRUE) &&

--- a/inst/unitTests/test_MulticoreParam.R
+++ b/inst/unitTests/test_MulticoreParam.R
@@ -1,3 +1,5 @@
+message("Testing MulticoreParam")
+
 test_MulticoreParam_progressbar <- function()
 {
     if (.Platform$OS.type == "windows")

--- a/inst/unitTests/test_SerialParam.R
+++ b/inst/unitTests/test_SerialParam.R
@@ -1,3 +1,5 @@
+message("Testing SerialParam")
+
 test_SerialParam_bpnworkers <- function() {
     checkIdentical(1L, bpnworkers(SerialParam()))
     checkIdentical(1L, bpnworkers(bpstart(SerialParam())))

--- a/inst/unitTests/test_SnowParam.R
+++ b/inst/unitTests/test_SnowParam.R
@@ -1,3 +1,5 @@
+message("Testing SnowParam")
+
 test_SnowParam_construction <- function()
 {
     checkException(SnowParam(logdir = tempdir()))
@@ -199,6 +201,3 @@ test_SnowParam_fallback <- function(){
     res <- bplapply(1, function(x) Sys.getpid(), BPPARAM = p)[[1]]
     checkTrue(res != Sys.getpid())
 }
-
-
-

--- a/inst/unitTests/test_bpaggregate.R
+++ b/inst/unitTests/test_bpaggregate.R
@@ -1,3 +1,5 @@
+message("Testing bpaggregate")
+
 test_bpaggregate <- 
     function() 
 {

--- a/inst/unitTests/test_bpexportglobals.R
+++ b/inst/unitTests/test_bpexportglobals.R
@@ -1,3 +1,5 @@
+message("Testing bpexportglobals")
+
 test_bpexportglobals_params <- function()
 {
     ## Multicore

--- a/inst/unitTests/test_bpiterate.R
+++ b/inst/unitTests/test_bpiterate.R
@@ -1,3 +1,5 @@
+message("Testing bpiterate")
+
 quiet <- suppressWarnings
 
 .lazyCount <- function(count) {
@@ -42,7 +44,8 @@ test_bpiterate_Params <- function()
         checkIdentical(expected, res)
     }
 
-    doParallel::registerDoParallel(2)
+    cl <- parallel::makeCluster(2)
+    doParallel::registerDoParallel(cl)
     params <- list(dopar=DoparParam(),
                    batchjobs=BatchJobsParam(2, progressbar=FALSE))
     for (p in params) {
@@ -51,8 +54,8 @@ test_bpiterate_Params <- function()
     }
 
     ## clean up
-    env <- foreach:::.foreachGlobals
-    rm(list=ls(name=env), pos=env)
+    foreach::registerDoSEQ()
+    parallel::stopCluster(cl)
     closeAllConnections()
     TRUE
 }

--- a/inst/unitTests/test_bplapply.R
+++ b/inst/unitTests/test_bplapply.R
@@ -1,8 +1,11 @@
+message("Testing bplapply")
+
 quiet <- suppressWarnings
 
 test_bplapply_Params <- function()
 {
-    doParallel::registerDoParallel(2)
+    cl <- parallel::makeCluster(2)
+    doParallel::registerDoParallel(cl)
     params <- list(serial=SerialParam(),
                    snow=SnowParam(2),
                    dopar=DoparParam(),
@@ -31,15 +34,16 @@ test_bplapply_Params <- function()
     checkTrue(all.equal(current[[2]], list(c("A", "B"), 1, 10)))
 
     ## clean up
-    env <- foreach:::.foreachGlobals
-    rm(list=ls(name=env), pos=env)
+    foreach::registerDoSEQ()
+    parallel::stopCluster(cl)
     closeAllConnections()
     TRUE
 }
 
 test_bplapply_symbols <- function()
 {
-    doParallel::registerDoParallel(2)
+    cl <- parallel::makeCluster(2)
+    doParallel::registerDoParallel(cl)
     params <- list(serial=SerialParam(),
                    snow=SnowParam(2),
                    dopar=DoparParam()
@@ -56,8 +60,8 @@ test_bplapply_symbols <- function()
     }
 
     ## clean up
-    env <- foreach:::.foreachGlobals
-    rm(list=ls(name=env), pos=env)
+    foreach::registerDoSEQ()
+    parallel::stopCluster(cl)
     closeAllConnections()
     TRUE
 }

--- a/inst/unitTests/test_bploop.R
+++ b/inst/unitTests/test_bploop.R
@@ -1,3 +1,5 @@
+message("Testing bploop")
+
 .lapplyReducer <- BiocParallel:::.lapplyReducer
 .iterateReducer <- BiocParallel:::.iterateReducer
 

--- a/inst/unitTests/test_bpoptions.R
+++ b/inst/unitTests/test_bpoptions.R
@@ -1,3 +1,5 @@
+message("Testing bpoptions")
+
 .checkMessage <- function(x) {
     message <- character()
     result <- withCallingHandlers(x, message = function(condition) {

--- a/inst/unitTests/test_bpvalidate.R
+++ b/inst/unitTests/test_bpvalidate.R
@@ -1,3 +1,5 @@
+message("Testing bpvalidate")
+
 BPValidate <- BiocParallel:::BPValidate
 
 test_bpvalidate_basic_ok <- function()

--- a/inst/unitTests/test_bpvec.R
+++ b/inst/unitTests/test_bpvec.R
@@ -1,6 +1,9 @@
+message("Testing bpvec")
+
 test_bpvec_Params <- function()
 {
-    doParallel::registerDoParallel(2)
+    cl <- parallel::makeCluster(2)
+    doParallel::registerDoParallel(cl)
     params <- list(serial=SerialParam(),
                    snow=SnowParam(2),
                    batchjobs=BatchJobsParam(2, progressbar=FALSE),
@@ -8,7 +11,7 @@ test_bpvec_Params <- function()
     if (.Platform$OS.type != "windows")
         params$mc <- MulticoreParam(2)
 
-    x <- rev(1:10) 
+    x <- rev(1:10)
     expected <- sqrt(x)
     for (param in names(params)) {
         current <- bpvec(x, sqrt, BPPARAM=params[[param]])
@@ -16,8 +19,8 @@ test_bpvec_Params <- function()
     }
 
     ## clean up
-    env <- foreach:::.foreachGlobals
-    rm(list=ls(name=env), pos=env)
+    foreach::registerDoSEQ()
+    parallel::stopCluster(cl)
     closeAllConnections()
     TRUE
 }

--- a/inst/unitTests/test_bpvectorize.R
+++ b/inst/unitTests/test_bpvectorize.R
@@ -1,6 +1,9 @@
+message("Testing bpvectorize")
+
 test_bpvectorize_Params <- function()
 {
-    doParallel::registerDoParallel(2)
+    cl <- parallel::makeCluster(2)
+    doParallel::registerDoParallel(cl)
     params <- list(serial=SerialParam(),
                    snow=SnowParam(2),
                    batchjobs=BatchJobsParam(2, progressbar=FALSE),
@@ -16,8 +19,8 @@ test_bpvectorize_Params <- function()
     }
 
     ## clean up
-    env <- foreach:::.foreachGlobals
-    rm(list=ls(name=env), pos=env)
+    foreach::registerDoSEQ()
+    parallel::stopCluster(cl)
     closeAllConnections()
     TRUE
 }

--- a/inst/unitTests/test_internal_rng_stream.R
+++ b/inst/unitTests/test_internal_rng_stream.R
@@ -1,3 +1,5 @@
+message("Testing internal_rng_stream")
+
 test_internal_rng_stream <-
     function()
 {

--- a/inst/unitTests/test_ipcmutex.R
+++ b/inst/unitTests/test_ipcmutex.R
@@ -1,3 +1,5 @@
+message("Testing ipcmutex")
+
 test_ipclock <- function()
 {
     id <- ipcid()

--- a/inst/unitTests/test_logging.R
+++ b/inst/unitTests/test_logging.R
@@ -1,3 +1,5 @@
+message("Testing logging")
+
 ## This code tests 'log' and 'progressbar'. test_errorhandling.R
 ## tests 'stop.on.error'
 
@@ -17,12 +19,11 @@ test_log <- function()
             bplapply(list(1, "2", 3), sqrt, BPPARAM=param)
         }, error=identity))
         checkTrue(is(res, "bplist_error"))
-        result <- attr(res, "result")
+        result <- bpresult(res)
         checkTrue(length(result) == 3L)
         msg <- "non-numeric argument to mathematical function"
         checkIdentical(conditionMessage(result[[2]]), msg)
         checkTrue(length(attr(result[[2]], "traceback")) > 0L)
-        closeAllConnections()
     }
 
     ## clean up

--- a/inst/unitTests/test_refclass.R
+++ b/inst/unitTests/test_refclass.R
@@ -1,3 +1,5 @@
+message("Testing refclass")
+
 test_SnowParam_refclass <- function()
 {
     p <- SnowParam(2)

--- a/inst/unitTests/test_rng.R
+++ b/inst/unitTests/test_rng.R
@@ -1,3 +1,5 @@
+message("Testing rng")
+
 test_rng_lapply <- function()
 {
     .rng_get_generator <- BiocParallel:::.rng_get_generator

--- a/inst/unitTests/test_utilities.R
+++ b/inst/unitTests/test_utilities.R
@@ -1,3 +1,5 @@
+message("Testing utilities")
+
 test_splitIndicies <- function()
 {
     .splitIndices <- BiocParallel:::.splitIndices


### PR DESCRIPTION
This pull request is for the issue https://github.com/Bioconductor/BiocParallel/issues/208. Even though we still do not know why the Win builder is not happy with `BiocParallel`, we can make the test result more readable. Hopefully, this change can help us to locate the issue. The changes include

1. Remove the error message from the worker due to the connection issue
2. Remove some unnecessary connection cleanup
3. Print out the file name being tested
4. use `bpresult` to obtain the results