### PR TITLE
add the deprecated BatchJobsParam to the document "BiocParallel-deprecated"

### DIFF
--- a/man/BiocParallel-deprecated.Rd
+++ b/man/BiocParallel-deprecated.Rd
@@ -1,0 +1,19 @@
+\name{BiocParallel-deprecated}
+\alias{BiocParallel-deprecated}
+\title{Deprecated functions in package \sQuote{BiocParallel}}
+
+\description{
+  These functions are provided for compatibility with older versions
+  of \sQuote{BiocParallel} only, and will be defunct at the next release.
+}
+
+\details{
+
+  The following functions are deprecated and will be made defunct; use
+  the replacement indicated below:
+  \itemize{
+
+    \item{BatchJobsParam: \code{\link{BatchtoolsParam}}}
+
+  }
+}


### PR DESCRIPTION
I forgot to commit the file "BiocParallel-deprecated" as stated in [Deprecation Guideline](https://contributions.bioconductor.org/deprecation.html#step-2-mark-the-function-as-defunct)