### PR TITLE
Fix bpmapply performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.31.13
+Version: 1.31.14
 Authors@R: c(
     person("Martin", "Morgan",
         email = "mtmorgan.bioc@gmail.com",

--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ USER VISIBLE CHANGES
 
 BUG FIXES
 
+    o (v 1.31.14) Reduce bpmapply memory usage
+
     o (v 1.31.1) suppress package startup messages on workers
     https://github.com/Bioconductor/BiocParallel/issues/198
 

--- a/R/bpmapply-methods.R
+++ b/R/bpmapply-methods.R
@@ -4,6 +4,11 @@
 
 ## bpmapply() dispatches to bplapply() where errors and logging are handled.
 
+.wrap <- function(.i, .FUN, .ddd, .MoreArgs) {
+    dots <- lapply(.ddd, `[`, .i)
+    .mapply(.FUN, dots, .MoreArgs)[[1L]]
+}
+
 setMethod("bpmapply", c("ANY", "BiocParallelParam"),
     function(FUN, ..., MoreArgs=NULL, SIMPLIFY=TRUE,
              USE.NAMES=TRUE, BPREDO=list(),
@@ -15,12 +20,8 @@ setMethod("bpmapply", c("ANY", "BiocParallelParam"),
         return(.mrename(list(), ddd, USE.NAMES))
 
     FUN <- match.fun(FUN)
-    wrap <- function(.i, .FUN, .ddd, .MoreArgs) {
-        dots <- lapply(.ddd, `[`, .i)
-        .mapply(.FUN, dots, .MoreArgs)[[1L]]
-    }
 
-    res <- bplapply(X=seq_along(ddd[[1L]]), wrap, .FUN=FUN, .ddd=ddd,
+    res <- bplapply(X=seq_along(ddd[[1L]]), .wrap, .FUN=FUN, .ddd=ddd,
                     .MoreArgs=MoreArgs, BPREDO=BPREDO,
                     BPPARAM=BPPARAM, BPOPTIONS = BPOPTIONS)
     .simplify(.mrename(res, ddd, USE.NAMES), SIMPLIFY)


### PR DESCRIPTION
bpmapply was passing all the ... to all the workers, making its memory consumption quite bad

In detail, the `wrap` function was defined nested under the environment of the bpmapply method.
When the wrap function was serialized, it included the environment of its parents, including the environment of the bpmapply method itself, that contains the ... of all the iterations.

This effectively forced passing all the iterations to all the workers, increasing the memory consumption.

By defining the wrap function outside of the method we reduce the size of its environment and get much better performance.