### PR TITLE
Force evaluation of the function argument

### DIFF
--- a/R/bpvalidate.R
+++ b/R/bpvalidate.R
@@ -124,6 +124,10 @@ setMethod("show", "BPValidate", function(object) {
         i <- vapply(unknown, function(x) {
             !exists(x, envir = env, inherits = FALSE)
         }, logical(1))
+        ## Force evaluation of the known arguments to
+        ## make sure they will be exported correctly
+        known <- unknown[-i]
+        for(nm in known) force(env[[nm]])
         unknown <- unknown[i]
         env <- parent.env(env)
     }

--- a/inst/unitTests/test_bpexportglobals.R
+++ b/inst/unitTests/test_bpexportglobals.R
@@ -42,3 +42,14 @@ test_bpexportglobals_bplapply <- function()
     current <- bplapply(1:2, function(i) getOption("BAR"), BPPARAM=param)
     checkIdentical("baz", unique(unlist(current)))
 }
+
+test_bpexportglobals_lazyEvaluation <- function(){
+    foo <- function(k){
+        param <- SnowParam(2L, exportglobals=TRUE)
+        bplapply(1:2, function(x){
+            k
+        }, BPPARAM = param)
+    }
+    k <- 1
+    checkIdentical(foo(k), list(1, 1))
+}


### PR DESCRIPTION
My git skill is a little bit rusty, I pushed to the master branch by accident. I have reverted the change but I think we can do a force reset to clean it up.

This is a pull request to solve the test 3 example in https://github.com/Bioconductor/BiocParallel/issues/241#issuecomment-1444297564. I force R to evaluate all function arguments before serializing the function object. This should solve the issue introduced by the delayed assignment.

