### PR TITLE
improve traceback in remote errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.33.10
+Version: 1.33.10.1
 Authors@R: c(
     person("Martin", "Morgan",
         email = "mtmorgan.bioc@gmail.com",


### PR DESCRIPTION
- do not report traceback 'above' the user-provided FUN in bplapply
- closes #245