### PR TITLE
remove static messages no longer used by bplapply

### DIFF
--- a/vignettes/Introduction_To_BiocParallel.Rmd
+++ b/vignettes/Introduction_To_BiocParallel.Rmd
@@ -599,7 +599,6 @@ Execute FUN 6 times across the workers.
 > FUN <- function(i) system("hostname", intern=TRUE)
 > bplapply(1:6, FUN, BPPARAM = param)
 bplapply(1:6, FUN, BPPARAM = param)
-        6 slaves are spawned successfully. 0 failed.
 [[1]]
 [1] "rhino01"
 
@@ -697,7 +696,6 @@ salloc: Granted job allocation 6762292
 > param <- SnowParam(mpi.universe.size() - 1, "MPI")
 > register(param)
 > xx <- bplapply(1:100, FUN)
-4 slaves are spawned successfully. 0 failed.
 > table(unlist(xx))
 gizmof13 gizmof71 gizmof86 gizmof88
 25 25 25 25


### PR DESCRIPTION
These messages are no longer used by `bplapply` and are best removed. 