### PR TITLE
Allow user-provided NULL value in bplapply

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocParallel
 Type: Package
 Title: Bioconductor facilities for parallel evaluation
-Version: 1.41.2
+Version: 1.41.3
 Authors@R: c(
     person("Martin", "Morgan",
         email = "mtmorgan.bioc@gmail.com",

--- a/inst/unitTests/test_bplapply.R
+++ b/inst/unitTests/test_bplapply.R
@@ -150,3 +150,12 @@ test_bplapply_auto_export <- function(){
     bpexportvariables(p) <- FALSE
     checkException(bplapply(1:2, fun2, BPPARAM = p), silent = TRUE)
 }
+
+
+test_bplapply_null_value_in_input <- function(){
+    p <- SerialParam()
+    FUN <- function(x) x
+    X <- list(a = 1, b = 2, c = NULL, d = 4)
+    result <- bptry(bplapply(X, FUN, BPPARAM = p))
+    checkIdentical(X, result)
+}


### PR DESCRIPTION
This is for solving the issue https://github.com/Bioconductor/BiocParallel/issues/267

The NULL value in bplappy will be replaced by a placeholder in the iterator. It will be replaced back with the real NULL before sending to the workers. A unit test was added to confirm this fix. 
