### PR TITLE
add bpworkers<- method for SerialParam

### DIFF
--- a/R/SerialParam-class.R
+++ b/R/SerialParam-class.R
@@ -128,6 +128,21 @@ setReplaceMethod(
 })
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Setters
+###
+
+setReplaceMethod("bpworkers", c("SerialParam", "numeric"),
+    function(x, value)
+{
+    value <- as.integer(value)
+    if (!identical(value, 1L))
+        .message(
+            "Number of workers limited to one for 'SerialParam'"
+        )
+    x
+})
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Backend method
 ###
 .SerialBackend <- setClass("SerialBackend", contains = "environment")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -104,6 +104,13 @@
     all(file.access(x, 6L) == 0L)
 }
 
+.message <- function(...) {
+    msg <- paste(
+        strwrap(paste0("\n", ...), indent = 2, exdent = 2), collapse="\n"
+    )
+    message(msg)
+}
+
 .warning <- function(...) {
     msg <- paste(
         strwrap(paste0("\n", ...), indent = 2, exdent = 2), collapse="\n"

--- a/man/bpmapply.Rd
+++ b/man/bpmapply.Rd
@@ -98,8 +98,7 @@ who <- c("sun", "moon")
 
 param <- bpparam()
 original <- bpworkers(param)
-if (!is(param, "SerialParam"))
-    bpworkers(param) <- 2
+bpworkers(param) <- 2
 result <- bpmapply(fun, greet, who, BPPARAM = param)
 cat(paste(result, collapse="\n"), "\n")
 bpworkers(param) <- original

--- a/man/bpmapply.Rd
+++ b/man/bpmapply.Rd
@@ -98,7 +98,8 @@ who <- c("sun", "moon")
 
 param <- bpparam()
 original <- bpworkers(param)
-bpworkers(param) <- 2
+if (!is(param, "SerialParam"))
+    bpworkers(param) <- 2
 result <- bpmapply(fun, greet, who, BPPARAM = param)
 cat(paste(result, collapse="\n"), "\n")
 bpworkers(param) <- original


### PR DESCRIPTION
Hi Martin, @mtmorgan 

For runners that only support the `SerialParam`, the example was causing an error: 

https://github.com/r-universe/bioconductor-source/actions/runs/15363737871/job/43276379856

The PR uses the `bpworkers<-` method conditionally. 

The other option is to create a `bpworkers<-` method for `SerialParam` that emits a warning and leaves the number of workers as `1`. 

Thanks!